### PR TITLE
Pin NeoForge dependency to 21.1.203

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # mc-rpg-mod
+
+This repository contains the RPG core and content modules for the NeoForge-based Minecraft mod.
+
+## Build requirements
+
+* Java 21 toolchain (configured via Gradle toolchains)
+* Gradle 8.x installation (or use the Gradle wrapper if present)
+* Internet access to `https://maven.neoforged.net/releases`
+
+## Dependency pinning
+
+The project now targets the tested NeoForge release `21.1.203`. If you previously built against a
+`21.1.+` snapshot, refresh your dependencies to ensure Gradle fetches the pinned build:
+
+```bash
+gradle --refresh-dependencies --console=plain
+```
+
+After refreshing, run the usual build to verify the dependencies resolve correctly:
+
+```bash
+gradle :rpg-core:build --console=plain
+```
+
+If the NeoForge repositories are temporarily unavailable, Gradle may report HTTP errors while
+resolving the `net.neoforged.gradle.userdev` plugin. Retry the build once access is restored.

--- a/rpg-core/build.gradle.kts
+++ b/rpg-core/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation("net.neoforged:neoforge:21.1.+")
+  implementation("net.neoforged:neoforge:21.1.203")
 }
 
 // Expande ${version} en mods.toml


### PR DESCRIPTION
## Summary
- pin the rpg-core module to the tested NeoForge 21.1.203 release instead of using the 21.1.+ range
- document the pinned version and dependency refresh steps in the README

## Testing
- gradle help --refresh-dependencies --console=plain --info *(fails: Maven repositories for net.neoforged.gradle.userdev returned HTTP 403)*
- gradle :rpg-core:build --console=plain *(fails: Maven repositories for net.neoforged.gradle.userdev returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d0acc1b74083269bf7ce42a96db1d0