### PR TITLE
Guard configuration resolution strategy mutation

### DIFF
--- a/rpg-core/build.gradle.kts
+++ b/rpg-core/build.gradle.kts
@@ -7,6 +7,10 @@ dependencies {
 }
 
 configurations.configureEach {
+  if (state != org.gradle.api.artifacts.Configuration.State.UNRESOLVED) {
+    return@configureEach
+  }
+
   resolutionStrategy.eachDependency {
     if (requested.group == "org.ow2.asm") {
       useVersion("9.8")


### PR DESCRIPTION
## Summary
- avoid mutating resolution strategy of configurations that have already been resolved
- keep enforcing ASM 9.8 for unresolved configurations

## Testing
- ⚠️ `./gradlew :rpg-core:runServer` *(fails: unable to download Gradle distribution due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bc05a94483268e3fc15e33911ff1