### PR TITLE
Use registry-aware buffers for player data payload

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/net/S2CPlayerData.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/net/S2CPlayerData.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import com.tuempresa.rpgcore.ModRpgCore;
 
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 
@@ -15,7 +16,7 @@ public record S2CPlayerData(String classId, int level, long xp, long currency) i
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(ModRpgCore.MOD_ID, "player_data");
     public static final CustomPacketPayload.Type<S2CPlayerData> TYPE = new CustomPacketPayload.Type<>(ID);
 
-    public static S2CPlayerData decode(FriendlyByteBuf buffer) {
+    public static S2CPlayerData decode(RegistryFriendlyByteBuf buffer) {
         Objects.requireNonNull(buffer, "buffer");
         String classId = buffer.readUtf(FriendlyByteBuf.MAX_STRING_LENGTH);
         int level = buffer.readVarInt();
@@ -30,7 +31,7 @@ public record S2CPlayerData(String classId, int level, long xp, long currency) i
     }
 
     @Override
-    public void write(FriendlyByteBuf buffer) {
+    public void write(RegistryFriendlyByteBuf buffer) {
         Objects.requireNonNull(buffer, "buffer");
         buffer.writeUtf(classId, FriendlyByteBuf.MAX_STRING_LENGTH);
         buffer.writeVarInt(level);


### PR DESCRIPTION
## Summary
- switch the S2C player data payload encode/decode helpers to use RegistryFriendlyByteBuf so the packet matches NeoForge's expectations

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d4526531bc8326814ca1d6af0ceae4