### PR TITLE
Add logging for player data lifecycle

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerData.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerData.java
@@ -21,6 +21,7 @@ public class PlayerData implements IPlayerData {
 
     public PlayerData() {
         this.level = 1;
+        ModRpgCore.LOG.debug(MARKER, "Initialized PlayerData attachment instance");
     }
 
     @Override
@@ -104,6 +105,7 @@ public class PlayerData implements IPlayerData {
         tag.putInt("level", level);
         tag.putLong("xp", xp);
         tag.putLong("currency", currency);
+        ModRpgCore.LOG.debug(MARKER, "Saving PlayerData[classId={}, level={}, xp={}, currency={}]", classId, level, xp, currency);
         return tag;
     }
 
@@ -121,6 +123,7 @@ public class PlayerData implements IPlayerData {
         setLevel(Math.max(1, storedLevel));
         setXp(Math.max(0L, storedXp));
         setCurrency(Math.max(0L, storedCurrency));
+        ModRpgCore.LOG.debug(MARKER, "Loaded PlayerData[classId={}, level={}, xp={}, currency={}]", classId, level, xp, currency);
     }
 
     public void copyFrom(IPlayerData other) {


### PR DESCRIPTION
## Summary
- add debug logging when player data attachments are constructed
- log the values written to and read from NBT for easier troubleshooting

## Testing
- `./gradlew :rpg-core:compileJava` *(fails: unable to download Gradle distribution because proxy returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d202d285048326bc765e2e1155c5a9