### PR TITLE
Handle player data cloning without copy-on-death

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataAttachment.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataAttachment.java
@@ -15,7 +15,6 @@ public final class PlayerDataAttachment {
   public static final Supplier<AttachmentType<PlayerData>> PLAYER_DATA =
       ATTACHMENTS.register("player_data", () ->
           AttachmentType.builder(PlayerData::new)
-              .copyOnDeath()
               .build()
       );
 

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataEvents.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataEvents.java
@@ -1,6 +1,7 @@
 package com.tuempresa.rpgcore.capability;
 
 import com.tuempresa.rpgcore.util.SyncUtil;
+import net.neoforged.neoforge.attachment.AttachmentType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -37,10 +38,16 @@ public final class PlayerDataEvents {
 
   @SubscribeEvent
   public void onClone(PlayerEvent.Clone event) {
-    if (event.getEntity() instanceof ServerPlayer player) {
-      saveToPersistentData(player);
-      SyncUtil.sync(player);
+    if (!(event.getEntity() instanceof ServerPlayer player)) {
+      return;
     }
+
+    AttachmentType<PlayerData> type = PlayerDataAttachment.PLAYER_DATA.get();
+    PlayerData oldData = event.getOriginal().getData(type);
+    PlayerData newData = player.getData(type);
+    newData.loadNBT(oldData.saveNBT());
+    saveToPersistentData(player);
+    SyncUtil.sync(player);
   }
 
   private static void saveToPersistentData(ServerPlayer player) {


### PR DESCRIPTION
## Summary
- remove `copyOnDeath` from the player data attachment registration
- manually copy the stored player data during `PlayerEvent.Clone` and keep it persisted/synced

## Testing
- `./gradlew :rpg-core:build` *(fails: Gradle wrapper cannot download dependencies because the proxy returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d45fd7986c832687d09f865faf121b