### PR TITLE
Add base dimensions and teleport utilities

### DIFF
--- a/rpg-content-base/src/main/resources/assets/rpg_content_base/lang/es_mx.json
+++ b/rpg-content-base/src/main/resources/assets/rpg_content_base/lang/es_mx.json
@@ -1,0 +1,5 @@
+{
+  "dimension.rpg_content_base.city": "Ciudad",
+  "dimension.rpg_content_base.field1": "Field 1",
+  "dimension.rpg_content_base.field2": "Field 2"
+}

--- a/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension/city.json
+++ b/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension/city.json
@@ -1,0 +1,11 @@
+{
+  "type": "rpg_content_base:city_type",
+  "generator": {
+    "type": "minecraft:noise",
+    "settings": "minecraft:overworld",
+    "biome_source": {
+      "type": "minecraft:fixed",
+      "biome": "minecraft:plains"
+    }
+  }
+}

--- a/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension/field1.json
+++ b/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension/field1.json
@@ -1,0 +1,11 @@
+{
+  "type": "rpg_content_base:field_type",
+  "generator": {
+    "type": "minecraft:noise",
+    "settings": "minecraft:overworld",
+    "biome_source": {
+      "type": "minecraft:fixed",
+      "biome": "minecraft:plains"
+    }
+  }
+}

--- a/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension/field2.json
+++ b/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension/field2.json
@@ -1,0 +1,11 @@
+{
+  "type": "rpg_content_base:field_type",
+  "generator": {
+    "type": "minecraft:noise",
+    "settings": "minecraft:overworld",
+    "biome_source": {
+      "type": "minecraft:fixed",
+      "biome": "minecraft:forest"
+    }
+  }
+}

--- a/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension_type/city_type.json
+++ b/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension_type/city_type.json
@@ -1,0 +1,14 @@
+{
+  "ultrawarm": false,
+  "natural": false,
+  "piglin_safe": false,
+  "respawn_anchor_works": true,
+  "bed_works": true,
+  "has_raids": false,
+  "min_y": -64,
+  "height": 384,
+  "logical_height": 384,
+  "coordinate_scale": 1.0,
+  "fixed_time": 6000,
+  "effects": "minecraft:overworld"
+}

--- a/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension_type/field_type.json
+++ b/rpg-content-base/src/main/resources/data/rpg_content_base/worldgen/dimension_type/field_type.json
@@ -1,0 +1,13 @@
+{
+  "ultrawarm": false,
+  "natural": true,
+  "piglin_safe": false,
+  "respawn_anchor_works": true,
+  "bed_works": true,
+  "has_raids": false,
+  "min_y": -64,
+  "height": 384,
+  "logical_height": 384,
+  "coordinate_scale": 1.0,
+  "effects": "minecraft:overworld"
+}

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/ModRpgCore.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/ModRpgCore.java
@@ -7,6 +7,7 @@ import com.tuempresa.rpgcore.capability.PlayerDataAttachment;
 import com.tuempresa.rpgcore.capability.PlayerDataEvents;
 import com.tuempresa.rpgcore.command.RpgCommands;
 import com.tuempresa.rpgcore.net.Net;
+import com.tuempresa.rpgcore.world.WorldEvents;
 
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -29,6 +30,7 @@ public final class ModRpgCore {
     // Y para eventos del JUEGO (como RegisterCommandsEvent), te registras en NeoForge.EVENT_BUS
     NeoForge.EVENT_BUS.register(this);
     PlayerDataEvents.registerOnGameBus();
+    WorldEvents.register();
   }
 
   // Evento del GAME bus (no del mod bus)

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/command/RpgCommands.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/command/RpgCommands.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.tuempresa.rpgcore.capability.PlayerData;
 import com.tuempresa.rpgcore.capability.PlayerDataAttachment;
 import com.tuempresa.rpgcore.util.SyncUtil;
+import com.tuempresa.rpgcore.util.TeleportUtil;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
@@ -38,6 +39,14 @@ public final class RpgCommands {
             .then(Commands.literal("set")
                 .then(Commands.argument("value", IntegerArgumentType.integer(1))
                     .executes(RpgCommands::setLevel))))
+        .then(Commands.literal("tp")
+            .requires(src -> src.hasPermission(2))
+            .then(Commands.literal("city")
+                .executes(ctx -> TeleportUtil.tpNamed(ctx.getSource().getPlayerOrException(), "rpg_content_base:city")))
+            .then(Commands.literal("field1")
+                .executes(ctx -> TeleportUtil.tpNamed(ctx.getSource().getPlayerOrException(), "rpg_content_base:field1")))
+            .then(Commands.literal("field2")
+                .executes(ctx -> TeleportUtil.tpNamed(ctx.getSource().getPlayerOrException(), "rpg_content_base:field2"))))
         .then(Commands.literal("money")
             .requires(src -> src.hasPermission(2))
             .then(Commands.literal("add")

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/util/TeleportUtil.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/util/TeleportUtil.java
@@ -1,0 +1,24 @@
+package com.tuempresa.rpgcore.util;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+
+public final class TeleportUtil {
+  private TeleportUtil() {}
+
+  public static int tpNamed(ServerPlayer player, String dimensionKey) {
+    var server = player.server;
+    ResourceKey<ServerLevel> key = ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(dimensionKey));
+    ServerLevel level = server.getLevel(key);
+    if (level == null) {
+      return 0;
+    }
+
+    var spawn = level.getSharedSpawnPos();
+    player.teleportTo(level, spawn.getX() + 0.5D, spawn.getY(), spawn.getZ() + 0.5D, player.getYRot(), player.getXRot());
+    return 1;
+  }
+}

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldEvents.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldEvents.java
@@ -1,0 +1,63 @@
+package com.tuempresa.rpgcore.world;
+
+import com.tuempresa.rpgcore.ModRpgCore;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.EntityType;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.living.MobSpawnEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
+
+public final class WorldEvents {
+  private WorldEvents() {}
+
+  public static void register() {
+    NeoForge.EVENT_BUS.register(new WorldEvents());
+  }
+
+  @SubscribeEvent
+  public void onLevelLoad(LevelEvent.Load event) {
+    if (!(event.getLevel() instanceof ServerLevel level)) {
+      return;
+    }
+
+    String key = level.dimension().location().toString();
+    int radius = switch (key) {
+      case "rpg_content_base:city" -> 120;
+      case "rpg_content_base:field1", "rpg_content_base:field2" -> 256;
+      default -> -1;
+    };
+
+    if (radius > 0) {
+      var border = level.getWorldBorder();
+      border.setCenter(0, 0);
+      border.setSize(radius * 2L);
+      ModRpgCore.LOG.debug("Aplicando world border de {} bloques al mundo {}", radius, key);
+    }
+  }
+
+  @SubscribeEvent
+  public void onFinalizeSpawn(MobSpawnEvent.FinalizeSpawn event) {
+    if (!(event.getLevel() instanceof ServerLevel level)) {
+      return;
+    }
+
+    String dimensionId = level.dimension().location().toString();
+    if ("rpg_content_base:field1".equals(dimensionId)) {
+      var type = event.getEntity().getType();
+      boolean allow = type == EntityType.SLIME || type == EntityType.RABBIT;
+      if (!allow) {
+        event.setCanceled(true);
+      }
+      return;
+    }
+
+    if ("rpg_content_base:field2".equals(dimensionId)) {
+      var type = event.getEntity().getType();
+      boolean allow = type == EntityType.WOLF || type == EntityType.SPIDER;
+      if (!allow) {
+        event.setCanceled(true);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add city, field1, and field2 dimension/type data and language entries to rpg-content-base
- introduce teleport command utilities and register warp command targets
- enforce world borders per dimension and restrict creature spawns for the new fields

## Testing
- ./gradlew :rpg-core:build :rpg-content-base:build *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d46a9ba1f08326bd1162789d54a9b2