### PR TITLE
Fix 1.21.1 API updates

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/api/QuestService.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/api/QuestService.java
@@ -104,16 +104,19 @@ public final class QuestService {
     }
   }
 
+  // TODO 1.21: reactivar COLLECT cuando el evento de pickup esté disponible
+  /*
   @SubscribeEvent
-  public void onItemPickup(PlayerEvent.ItemPickupEvent event) {
+  public void onItemPickup(net.neoforged.neoforge.event.entity.player.ItemEntityPickupEvent event) {
     if (!(event.getEntity() instanceof ServerPlayer player)) {
       return;
     }
-    ItemStack stack = event.getStack();
+    ItemStack stack = event.getItemEntity().getItem();
     for (CollectHandler handler : COLLECT_HANDLERS) {
       handler.onCollect(player, stack.copy());
     }
   }
+  */
 
   @SubscribeEvent
   public void onDimensionChange(PlayerEvent.PlayerChangedDimensionEvent event) {

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/pack/PackManifestData.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/pack/PackManifestData.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -16,9 +17,9 @@ import net.neoforged.fml.ModList;
  * instalación actual. Se almacena únicamente con fines de diagnóstico.
  */
 public final class PackManifestData extends SavedData {
-  private static final String DATA_NAME = "rpg_core_pack_manifest";
-  private static final SavedData.Factory<PackManifestData> FACTORY = new SavedData.Factory<>(
-      PackManifestData::new, PackManifestData::load);
+  public static final String DATA_NAME = "rpg_core_pack_manifest";
+  public static final SavedData.Factory<PackManifestData> FACTORY = new SavedData.Factory<>(
+      PackManifestData::new, PackManifestData::load, null);
 
   private final Map<String, String> packs = new TreeMap<>();
 
@@ -28,7 +29,7 @@ public final class PackManifestData extends SavedData {
     return level.getDataStorage().computeIfAbsent(FACTORY, DATA_NAME);
   }
 
-  public static PackManifestData load(CompoundTag tag) {
+  public static PackManifestData load(CompoundTag tag, HolderLookup.Provider registries) {
     PackManifestData data = new PackManifestData();
     ListTag list = tag.getList("packs", Tag.TAG_COMPOUND);
     for (Tag element : list) {
@@ -45,7 +46,7 @@ public final class PackManifestData extends SavedData {
   }
 
   @Override
-  public CompoundTag save(CompoundTag tag) {
+  public CompoundTag save(CompoundTag tag, HolderLookup.Provider registries) {
     ListTag list = new ListTag();
     for (Map.Entry<String, String> entry : packs.entrySet()) {
       CompoundTag item = new CompoundTag();

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/util/TeleportUtil.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/util/TeleportUtil.java
@@ -5,13 +5,14 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
 
 public final class TeleportUtil {
   private TeleportUtil() {}
 
   public static int tpNamed(ServerPlayer player, String dimensionKey) {
     var server = player.server;
-    ResourceKey<ServerLevel> key = ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(dimensionKey));
+    ResourceKey<Level> key = ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(dimensionKey));
     ServerLevel level = server.getLevel(key);
     if (level == null) {
       return 0;


### PR DESCRIPTION
## Summary
- fix TeleportUtil to use ResourceKey<Level> for dimension lookups
- update PackManifestData to the 1.21 SavedData API
- temporarily disable quest item pickup handler until the new event is wired up

## Testing
- `./gradlew :rpg-core:compileJava` *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d47a85d5a88326a8080ed639755592