### PR TITLE
Load prontera pack via runtime dependency

### DIFF
--- a/rpg-core/build.gradle.kts
+++ b/rpg-core/build.gradle.kts
@@ -1,11 +1,10 @@
-import net.neoforged.gradle.userdev.UserDevPluginExtension
-
 plugins {
   id("net.neoforged.gradle.userdev") version "7.0.145"
 }
 
 dependencies {
   implementation("net.neoforged:neoforge:21.1.203")
+  runtimeOnly(project(":rpg-content-prontera"))
 }
 
 configurations.configureEach {
@@ -17,31 +16,6 @@ configurations.configureEach {
     if (requested.group == "org.ow2.asm") {
       useVersion("9.8")
       because("Align ASM version with NeoForge userdev module-path jars")
-    }
-  }
-}
-
-extensions.configure<UserDevPluginExtension>("userdev") {
-  runs {
-    named("client") {
-      mods {
-        create("rpg_core") {
-          source(sourceSets.main.get())
-        }
-        create("rpg_content_prontera") {
-          source(project(":rpg-content-prontera").sourceSets.main.get())
-        }
-      }
-    }
-    named("server") {
-      mods {
-        create("rpg_core") {
-          source(sourceSets.main.get())
-        }
-        create("rpg_content_prontera") {
-          source(project(":rpg-content-prontera").sourceSets.main.get())
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove explicit userdev run configuration for including the Prontera content pack
- add runtimeOnly dependency so runClient includes the Prontera module automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4871978b88326bf5a7e7b19ee77cf