### PR TITLE
Handle missing Prontera pack more gracefully

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/ModRpgCore.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/ModRpgCore.java
@@ -21,6 +21,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.fml.ModList;
 
 @Mod(ModRpgCore.MOD_ID)
 public final class ModRpgCore {
@@ -46,6 +47,12 @@ public final class ModRpgCore {
   }
 
   private static void registerDefaultWarps() {
+    if (!ModList.get().isLoaded("rpg_content_prontera")) {
+      LOG.warn(
+          "El pack rpg-content-prontera no está presente; se omite el registro de warps por defecto.");
+      return;
+    }
+
     registerWarp("prontera/city");
     registerWarp("prontera/field1");
     registerWarp("prontera/field2");

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataEvents.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataEvents.java
@@ -2,10 +2,15 @@ package com.tuempresa.rpgcore.capability;
 
 import com.tuempresa.rpgcore.api.WarpService;
 import com.tuempresa.rpgcore.util.SyncUtil;
+
+import java.util.Optional;
+
 import net.neoforged.neoforge.attachment.AttachmentType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
@@ -31,12 +36,20 @@ public final class PlayerDataEvents {
       SyncUtil.sync(player);
 
       if (!persistentData.getBoolean(AUTO_WARP_KEY)) {
+        Optional<ResourceKey<Level>> warp = WarpService.getWarp("prontera/city");
+        if (warp.isEmpty()) {
+          player.sendSystemMessage(Component.literal(
+              "[RPG] El pack Prontera no está instalado. Añade rpg-content-prontera a mods/ o datapacks."));
+          return;
+        }
+
         boolean teleported = WarpService.teleport(player, "prontera/city");
         if (teleported) {
           persistentData.putBoolean(AUTO_WARP_KEY, true);
           player.sendSystemMessage(Component.literal("[RPG] Bienvenido a Prontera."));
         } else {
-          player.sendSystemMessage(Component.literal("[RPG] No se pudo cargar Prontera. Verifica los packs instalados."));
+          player.sendSystemMessage(Component.literal(
+              "[RPG] No se pudo cargar la dimensión de Prontera. Crea un mundo nuevo tras instalar el pack."));
         }
       }
     }


### PR DESCRIPTION
## Summary
- skip registering Prontera warps when the rpg-content-prontera pack is missing and log a warning
- inform players on login when the Prontera pack is absent before attempting the auto-warp
- adjust the failure message to suggest recreating the world after installing the pack

## Testing
- `./gradlew :rpg-core:check` *(fails: Gradle wrapper download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a17456fc832690564467c464bdfa