### PR TITLE
Fix dimension type definitions for Prontera pack

### DIFF
--- a/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/city_type.json
+++ b/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/city_type.json
@@ -5,10 +5,22 @@
   "respawn_anchor_works": true,
   "bed_works": true,
   "has_raids": false,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "ambient_light": 0.0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": {
+      "min_inclusive": 0,
+      "max_inclusive": 7
+    }
+  },
+  "monster_spawn_block_light_limit": 0,
   "min_y": -64,
   "height": 384,
   "logical_height": 384,
   "coordinate_scale": 1.0,
   "fixed_time": 6000,
-  "effects": "minecraft:overworld"
+  "effects": "minecraft:overworld",
+  "infiniburn": "minecraft:infiniburn_overworld"
 }

--- a/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/field_type.json
+++ b/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/field_type.json
@@ -5,9 +5,21 @@
   "respawn_anchor_works": true,
   "bed_works": true,
   "has_raids": false,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "ambient_light": 0.0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": {
+      "min_inclusive": 0,
+      "max_inclusive": 7
+    }
+  },
+  "monster_spawn_block_light_limit": 0,
   "min_y": -64,
   "height": 384,
   "logical_height": 384,
   "coordinate_scale": 1.0,
-  "effects": "minecraft:overworld"
+  "effects": "minecraft:overworld",
+  "infiniburn": "minecraft:infiniburn_overworld"
 }


### PR DESCRIPTION
## Summary
- add the required 1.21 dimension type fields to the Prontera dimension definitions so they load correctly

## Testing
- `./gradlew :rpg-content-prontera:runData` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b16e948c832681720b0ccab9b795