### PR TITLE
Update built-in pack metadata for 1.21

### DIFF
--- a/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/city_type.json
+++ b/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/city_type.json
@@ -5,10 +5,22 @@
   "respawn_anchor_works": true,
   "bed_works": true,
   "has_raids": false,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "ambient_light": 0.0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": {
+      "min_inclusive": 0,
+      "max_inclusive": 7
+    }
+  },
+  "monster_spawn_block_light_limit": 0,
   "min_y": -64,
   "height": 384,
   "logical_height": 384,
   "coordinate_scale": 1.0,
   "fixed_time": 6000,
-  "effects": "minecraft:overworld"
+  "effects": "minecraft:overworld",
+  "infiniburn": "minecraft:infiniburn_overworld"
 }

--- a/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/field_type.json
+++ b/rpg-content-prontera/src/main/resources/data/rpg_content_prontera/dimension_type/field_type.json
@@ -5,9 +5,21 @@
   "respawn_anchor_works": true,
   "bed_works": true,
   "has_raids": false,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "ambient_light": 0.0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": {
+      "min_inclusive": 0,
+      "max_inclusive": 7
+    }
+  },
+  "monster_spawn_block_light_limit": 0,
   "min_y": -64,
   "height": 384,
   "logical_height": 384,
   "coordinate_scale": 1.0,
-  "effects": "minecraft:overworld"
+  "effects": "minecraft:overworld",
+  "infiniburn": "minecraft:infiniburn_overworld"
 }

--- a/rpg-content-prontera/src/main/resources/pack.mcmeta
+++ b/rpg-content-prontera/src/main/resources/pack.mcmeta
@@ -1,1 +1,16 @@
-{ "pack": { "pack_format": 48, "description": "RPG Content: Prontera" } }
+{
+  "pack": {
+    "pack_format": 57,
+    "supported_formats": {
+      "resource": {
+        "min_inclusive": 32,
+        "max_inclusive": 32
+      },
+      "data": {
+        "min_inclusive": 57,
+        "max_inclusive": 57
+      }
+    },
+    "description": "RPG Content: Prontera"
+  }
+}

--- a/rpg-core/src/main/resources/pack.mcmeta
+++ b/rpg-core/src/main/resources/pack.mcmeta
@@ -1,1 +1,16 @@
-{ "pack": { "pack_format": 48, "description": "RPG Core Assets" } }
+{
+  "pack": {
+    "pack_format": 57,
+    "supported_formats": {
+      "resource": {
+        "min_inclusive": 32,
+        "max_inclusive": 32
+      },
+      "data": {
+        "min_inclusive": 57,
+        "max_inclusive": 57
+      }
+    },
+    "description": "RPG Core Assets"
+  }
+}

--- a/rpg-mobs-pack-1/src/main/resources/pack.mcmeta
+++ b/rpg-mobs-pack-1/src/main/resources/pack.mcmeta
@@ -1,1 +1,16 @@
-{ "pack": { "pack_format": 48, "description": "RPG Mobs Pack 1" } }
+{
+  "pack": {
+    "pack_format": 57,
+    "supported_formats": {
+      "resource": {
+        "min_inclusive": 32,
+        "max_inclusive": 32
+      },
+      "data": {
+        "min_inclusive": 57,
+        "max_inclusive": 57
+      }
+    },
+    "description": "RPG Mobs Pack 1"
+  }
+}

--- a/rpg-weapons-pack-1/src/main/resources/pack.mcmeta
+++ b/rpg-weapons-pack-1/src/main/resources/pack.mcmeta
@@ -1,1 +1,16 @@
-{ "pack": { "pack_format": 48, "description": "RPG Weapons Pack 1" } }
+{
+  "pack": {
+    "pack_format": 57,
+    "supported_formats": {
+      "resource": {
+        "min_inclusive": 32,
+        "max_inclusive": 32
+      },
+      "data": {
+        "min_inclusive": 57,
+        "max_inclusive": 57
+      }
+    },
+    "description": "RPG Weapons Pack 1"
+  }
+}


### PR DESCRIPTION
## Summary
- update every bundled pack's pack.mcmeta to advertise the 1.21 resource (32) and data (57) pack formats so NeoForge treats them as compatible

## Testing
- `./gradlew :rpg-content-prontera:runData` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b16e948c832681720b0ccab9b795