### PR TITLE
Add world border hooks for RPG dimensions

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/ModRpgCore.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/ModRpgCore.java
@@ -10,6 +10,7 @@ import com.tuempresa.rpgcore.capability.PlayerDataEvents;
 import com.tuempresa.rpgcore.command.RpgCommands;
 import com.tuempresa.rpgcore.net.Net;
 import com.tuempresa.rpgcore.pack.PackManifestTracker;
+import com.tuempresa.rpgcore.world.WorldBorderHooks;
 import com.tuempresa.rpgcore.world.WorldEvents;
 
 import net.minecraft.core.registries.Registries;
@@ -44,6 +45,7 @@ public final class ModRpgCore {
     NeoForge.EVENT_BUS.register(this);
     PlayerDataEvents.registerOnGameBus();
     WorldEvents.register();
+    WorldBorderHooks.register();
   }
 
   private static void registerDefaultWarps() {

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderHooks.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderHooks.java
@@ -1,0 +1,35 @@
+package com.tuempresa.rpgcore.world;
+
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.level.LevelEvent;
+import net.minecraft.server.level.ServerLevel;
+
+public final class WorldBorderHooks {
+  public static void register() {
+    NeoForge.EVENT_BUS.register(new WorldBorderHooks());
+  }
+
+  @SubscribeEvent
+  public void onLevelLoad(LevelEvent.Load e) {
+    if (!(e.getLevel() instanceof ServerLevel level)) return;
+
+    String id = level.dimension().location().toString();
+    // define el diámetro por dimensión
+    double diameter =
+        switch (id) {
+          case "rpg_content_prontera:city" -> 480.0; // ~240x240
+          case "rpg_content_prontera:field1" -> 1024.0; // ~512x512
+          case "rpg_content_prontera:field2" -> 1024.0; // ~512x512
+          default -> -1.0;
+        };
+
+    if (diameter > 0) {
+      var wb = level.getWorldBorder();
+      wb.setCenter(0.0, 0.0);
+      wb.setSize(diameter); // diámetro, no radio
+      wb.setDamageAmount(0.2); // opcional
+      wb.setWarningBlocks(6); // opcional
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a world-border listener that enforces custom diameters per RPG dimension on load
- register the listener from the core mod initialization so it runs for each loaded dimension

## Testing
- ./gradlew :rpg-core:build *(fails: Unable to tunnel through proxy to download Gradle 9.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b9fb3d308326bbd29750633475d4