### PR TITLE
Fix world border hook compilation error

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderHooks.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderHooks.java
@@ -28,7 +28,6 @@ public final class WorldBorderHooks {
       var wb = level.getWorldBorder();
       wb.setCenter(0.0, 0.0);
       wb.setSize(diameter); // diámetro, no radio
-      wb.setDamageAmount(0.2); // opcional
       wb.setWarningBlocks(6); // opcional
     }
   }


### PR DESCRIPTION
## Summary
- remove the unsupported `setDamageAmount` call from the world border hook so it compiles against the targeted API

## Testing
- `./gradlew :rpg-core:compileJava` *(fails: Gradle wrapper cannot download distribution due to proxy restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4bd9e8f708326be92b9c9301b4633