### PR TITLE
Configure world borders per dimension

### DIFF
--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataEvents.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/capability/PlayerDataEvents.java
@@ -2,6 +2,7 @@ package com.tuempresa.rpgcore.capability;
 
 import com.tuempresa.rpgcore.api.WarpService;
 import com.tuempresa.rpgcore.util.SyncUtil;
+import com.tuempresa.rpgcore.world.WorldBorderConfig;
 
 import java.util.Optional;
 
@@ -28,6 +29,8 @@ public final class PlayerDataEvents {
   @SubscribeEvent
   public void onLogin(PlayerEvent.PlayerLoggedInEvent event) {
     if (event.getEntity() instanceof ServerPlayer player) {
+      WorldBorderConfig.apply(player.serverLevel());
+
       CompoundTag persistentData = player.getPersistentData();
       if (persistentData.contains(NBT_KEY)) {
         PlayerData playerData = player.getData(PlayerDataAttachment.PLAYER_DATA.get());

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/util/TeleportUtil.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/util/TeleportUtil.java
@@ -1,5 +1,7 @@
 package com.tuempresa.rpgcore.util;
 
+import com.tuempresa.rpgcore.world.WorldBorderConfig;
+
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -17,6 +19,8 @@ public final class TeleportUtil {
     if (level == null) {
       return 0;
     }
+
+    WorldBorderConfig.apply(level);
 
     var spawn = level.getSharedSpawnPos();
     player.teleportTo(level, spawn.getX() + 0.5D, spawn.getY(), spawn.getZ() + 0.5D, player.getYRot(), player.getXRot());

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderConfig.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderConfig.java
@@ -1,0 +1,36 @@
+package com.tuempresa.rpgcore.world;
+
+import java.util.Map;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.border.WorldBorder;
+
+public final class WorldBorderConfig {
+  private static final Map<ResourceLocation, Integer> BORDER_SIZES =
+      Map.ofEntries(
+          Map.entry(ResourceLocation.fromNamespaceAndPath("rpg_content_prontera", "city"), 128),
+          Map.entry(ResourceLocation.fromNamespaceAndPath("rpg_content_prontera", "field1"), 512),
+          Map.entry(ResourceLocation.fromNamespaceAndPath("rpg_content_prontera", "field2"), 512),
+          Map.entry(ResourceLocation.fromNamespaceAndPath("rpg_content_prontera", "dungeon1"), 192));
+
+  private WorldBorderConfig() {}
+
+  public static void apply(ServerLevel level) {
+    if (level == null) {
+      return;
+    }
+
+    WorldBorder border = level.getWorldBorder();
+    ResourceLocation dimension = level.dimension().location();
+    Integer size = BORDER_SIZES.get(dimension);
+
+    if (size == null) {
+      return;
+    }
+
+    border.setCenter(0.0D, 0.0D);
+    border.setSize(size.doubleValue());
+    border.setWarningBlocks(3);
+  }
+}

--- a/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderHooks.java
+++ b/rpg-core/src/main/java/com/tuempresa/rpgcore/world/WorldBorderHooks.java
@@ -11,26 +11,9 @@ public final class WorldBorderHooks {
   }
 
   @SubscribeEvent
-  public void onLevelLoad(LevelEvent.Load e) {
-    if (!(e.getLevel() instanceof ServerLevel level)) return;
-
-    String id = level.dimension().location().toString();
-    // define el diámetro por dimensión
-    double diameter =
-        switch (id) {
-          case "rpg_content_prontera:city" -> 480.0; // ~240x240
-          case "rpg_content_prontera:field1" -> 1024.0; // ~512x512
-          case "rpg_content_prontera:field2" -> 1024.0; // ~512x512
-          default -> -1.0;
-        };
-
-    if (diameter > 0) {
-      var wb = level.getWorldBorder();
-      wb.setCenter(0.0, 0.0);
-      wb.setSize(diameter); // diámetro total
-      wb.setDamagePerBlock(0.2); // opcional: daño al cruzar
-      wb.setDamageSafeZone(5.0); // opcional: zona sin daño
-      wb.setWarningBlocks(6); // opcional: aviso visual
+  public void onLevelLoad(LevelEvent.Load event) {
+    if (event.getLevel() instanceof ServerLevel level) {
+      WorldBorderConfig.apply(level);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a shared `WorldBorderConfig` with explicit sizes for Prontera dimensions
- reuse the configuration when levels load, players log in, and teleports occur to keep borders consistent

## Testing
- `./gradlew :rpg-core:build` *(fails: unable to download Gradle due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c327f6c08326b7eac6d78a7ccbbd