### PR TITLE
Add dungeon data reload infrastructure and command

### DIFF
--- a/src/main/java/com/tuempresa/rogue/RogueEvents.java
+++ b/src/main/java/com/tuempresa/rogue/RogueEvents.java
@@ -1,0 +1,50 @@
+package com.tuempresa.rogue;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.tuempresa.rogue.data.DungeonDataException;
+import com.tuempresa.rogue.data.DungeonDataReloader;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.AddReloadListenerEvent;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+
+/**
+ * Handles Forge level events such as command registration and data reload listeners.
+ */
+@Mod.EventBusSubscriber(modid = RogueMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public final class RogueEvents {
+    private RogueEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onAddReloadListeners(AddReloadListenerEvent event) {
+        event.addListener(DungeonDataReloader.getInstance());
+    }
+
+    @SubscribeEvent
+    public static void onRegisterCommands(RegisterCommandsEvent event) {
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+        dispatcher.register(Commands.literal(RogueMod.MOD_ID)
+            .requires(source -> source.hasPermission(2))
+            .then(Commands.literal("reload")
+                .executes(context -> reloadDungeonData(context.getSource()))));
+    }
+
+    private static int reloadDungeonData(CommandSourceStack source) {
+        DungeonDataReloader reloader = DungeonDataReloader.getInstance();
+        try {
+            reloader.reloadNow(source.getServer());
+            source.sendSuccess(() -> Component.literal(
+                "Se recargaron " + reloader.dungeons().size() + " mazmorras y " + reloader.portals().size() + " portales."),
+                true);
+            return 1;
+        } catch (DungeonDataException e) {
+            RogueMod.LOGGER.error("Error recargando datos de mazmorras", e);
+            source.sendFailure(Component.literal("Error al recargar mazmorras: " + e.getMessage()));
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/RogueMod.java
+++ b/src/main/java/com/tuempresa/rogue/RogueMod.java
@@ -1,6 +1,7 @@
 package com.tuempresa.rogue;
 
 import com.mojang.logging.LogUtils;
+import com.tuempresa.rogue.data.DungeonDataReloader;
 import net.neoforged.fml.common.Mod;
 import org.slf4j.Logger;
 
@@ -12,6 +13,7 @@ import org.slf4j.Logger;
 public final class RogueMod {
     public static final String MOD_ID = "rogue";
     public static final Logger LOGGER = LogUtils.getLogger();
+    public static final DungeonDataReloader DUNGEON_DATA = DungeonDataReloader.getInstance();
 
     public RogueMod() {
         LOGGER.info("Inicializando el mod {}", MOD_ID);

--- a/src/main/java/com/tuempresa/rogue/data/DungeonDataException.java
+++ b/src/main/java/com/tuempresa/rogue/data/DungeonDataException.java
@@ -1,0 +1,14 @@
+package com.tuempresa.rogue.data;
+
+/**
+ * Generic runtime exception thrown when dungeon data fails validation or cannot be parsed.
+ */
+public class DungeonDataException extends RuntimeException {
+    public DungeonDataException(String message) {
+        super(message);
+    }
+
+    public DungeonDataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/DungeonDataReloader.java
+++ b/src/main/java/com/tuempresa/rogue/data/DungeonDataReloader.java
@@ -1,0 +1,117 @@
+package com.tuempresa.rogue.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.data.model.DungeonDef;
+import com.tuempresa.rogue.data.model.PortalDef;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reload listener responsible for parsing dungeon definitions.
+ */
+public final class DungeonDataReloader extends SimpleJsonResourceReloadListener {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final DungeonDataReloader INSTANCE = new DungeonDataReloader();
+
+    private Map<ResourceLocation, PortalDef> portalDefs = Map.of();
+    private Map<ResourceLocation, DungeonDef> dungeonDefs = Map.of();
+
+    private DungeonDataReloader() {
+        super(GSON, "dungeons");
+    }
+
+    public static DungeonDataReloader getInstance() {
+        return INSTANCE;
+    }
+
+    public Map<ResourceLocation, PortalDef> portals() {
+        return portalDefs;
+    }
+
+    public Map<ResourceLocation, DungeonDef> dungeons() {
+        return dungeonDefs;
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> preparedData,
+                         ResourceManager resourceManager,
+                         ProfilerFiller profiler) {
+        Map<ResourceLocation, PortalDef> portals = new HashMap<>();
+        Map<ResourceLocation, DungeonDef> dungeons = new HashMap<>();
+        List<String> errors = new ArrayList<>();
+
+        preparedData.forEach((fileId, jsonElement) -> {
+            if (!RogueMod.MOD_ID.equals(fileId.getNamespace())) {
+                return;
+            }
+
+            try {
+                JsonObject root = GsonHelper.convertToJsonObject(jsonElement, "root");
+                if (!root.has("portal")) {
+                    throw new DungeonDataException("Falta la sección 'portal'");
+                }
+                if (!root.has("dungeon")) {
+                    throw new DungeonDataException("Falta la sección 'dungeon'");
+                }
+
+                PortalDef portal = PortalDef.fromJson(fileId, GsonHelper.getAsJsonObject(root, "portal"));
+                DungeonDef dungeon = DungeonDef.fromJson(fileId, GsonHelper.getAsJsonObject(root, "dungeon"));
+
+                if (portals.putIfAbsent(portal.id(), portal) != null) {
+                    throw new DungeonDataException("Portal duplicado con id " + portal.id());
+                }
+                if (dungeons.putIfAbsent(dungeon.id(), dungeon) != null) {
+                    throw new DungeonDataException("Mazmorra duplicada con id " + dungeon.id());
+                }
+            } catch (DungeonDataException e) {
+                errors.add("[" + fileId + "] " + e.getMessage());
+            } catch (Exception e) {
+                errors.add("[" + fileId + "] Error inesperado: " + e.getMessage());
+            }
+        });
+
+        portals.values().forEach(portal -> {
+            if (!dungeons.containsKey(portal.dungeonId())) {
+                errors.add("El portal " + portal.id() + " referencia una mazmorra inexistente " + portal.dungeonId());
+            }
+        });
+
+        if (!errors.isEmpty()) {
+            errors.forEach(error -> RogueMod.LOGGER.error("Fallo cargando mazmorra: {}", error));
+            throw new DungeonDataException("Se encontraron " + errors.size() + " errores al cargar las mazmorras");
+        }
+
+        this.portalDefs = Collections.unmodifiableMap(new HashMap<>(portals));
+        this.dungeonDefs = Collections.unmodifiableMap(new HashMap<>(dungeons));
+        RogueMod.LOGGER.info("Cargadas {} mazmorras y {} portales", dungeonDefs.size(), portalDefs.size());
+    }
+
+    public void reloadNow(ResourceManager resourceManager) {
+        try {
+            Map<ResourceLocation, JsonElement> prepared = this.prepare(resourceManager, ProfilerFiller.EMPTY);
+            this.apply(prepared, resourceManager, ProfilerFiller.EMPTY);
+        } catch (DungeonDataException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DungeonDataException("Error recargando datos de mazmorras", e);
+        }
+    }
+
+    public void reloadNow(MinecraftServer server) {
+        reloadNow(server.getServerResources().resourceManager());
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/model/DungeonDef.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/DungeonDef.java
@@ -1,0 +1,83 @@
+package com.tuempresa.rogue.data.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.data.DungeonDataException;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Definition of a dungeon composed of rooms and rewards.
+ */
+public final class DungeonDef {
+    private final ResourceLocation id;
+    private final String displayName;
+    private final List<RoomDef> rooms;
+    private final RewardsDef rewards;
+
+    public DungeonDef(ResourceLocation id, String displayName, List<RoomDef> rooms, RewardsDef rewards) {
+        this.id = id;
+        this.displayName = displayName;
+        this.rooms = Collections.unmodifiableList(new ArrayList<>(rooms));
+        this.rewards = rewards;
+    }
+
+    public ResourceLocation id() {
+        return id;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public List<RoomDef> rooms() {
+        return rooms;
+    }
+
+    public RewardsDef rewards() {
+        return rewards;
+    }
+
+    public static DungeonDef fromJson(ResourceLocation fileId, JsonObject json) {
+        ResourceLocation id = parseResourceId(json, "id", fileId);
+        String displayName = GsonHelper.getAsString(json, "display_name", id.toString()).trim();
+        if (displayName.isEmpty()) {
+            throw new DungeonDataException("La mazmorra " + id + " requiere display_name");
+        }
+
+        if (!json.has("rooms")) {
+            throw new DungeonDataException("La mazmorra " + id + " requiere rooms");
+        }
+        JsonArray roomsArray = GsonHelper.getAsJsonArray(json, "rooms");
+        if (roomsArray.isEmpty()) {
+            throw new DungeonDataException("La mazmorra " + id + " debe tener al menos una sala");
+        }
+
+        List<RoomDef> rooms = new ArrayList<>();
+        for (JsonElement element : roomsArray) {
+            JsonObject roomObject = GsonHelper.convertToJsonObject(element, "room");
+            rooms.add(RoomDef.fromJson(roomObject));
+        }
+
+        if (!json.has("rewards")) {
+            throw new DungeonDataException("La mazmorra " + id + " requiere rewards");
+        }
+        RewardsDef rewards = RewardsDef.fromJson(GsonHelper.getAsJsonObject(json, "rewards"));
+
+        return new DungeonDef(id, displayName, rooms, rewards);
+    }
+
+    private static ResourceLocation parseResourceId(JsonObject json, String field, ResourceLocation fallback) {
+        String rawId = GsonHelper.getAsString(json, field, fallback.toString());
+        ResourceLocation id = ResourceLocation.tryParse(rawId);
+        if (id == null) {
+            throw new DungeonDataException("Identificador inválido para la mazmorra: " + rawId);
+        }
+        return id;
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/model/MobEntry.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/MobEntry.java
@@ -1,0 +1,53 @@
+package com.tuempresa.rogue.data.model;
+
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.data.DungeonDataException;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+
+/**
+ * Entry describing a mob that will appear in a wave.
+ */
+public final class MobEntry {
+    private final ResourceLocation entityType;
+    private final int count;
+    private final int spawnDelay;
+
+    public MobEntry(ResourceLocation entityType, int count, int spawnDelay) {
+        this.entityType = entityType;
+        this.count = count;
+        this.spawnDelay = spawnDelay;
+    }
+
+    public ResourceLocation entityType() {
+        return entityType;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    public int spawnDelay() {
+        return spawnDelay;
+    }
+
+    public static MobEntry fromJson(JsonObject json) {
+        String rawType = GsonHelper.getAsString(json, "type");
+        ResourceLocation entityType = ResourceLocation.tryParse(rawType);
+        if (entityType == null) {
+            throw new DungeonDataException("Tipo de entidad inválido: " + rawType);
+        }
+
+        int count = GsonHelper.getAsInt(json, "count", 1);
+        if (count <= 0) {
+            throw new DungeonDataException("El valor count debe ser positivo para el mob " + entityType);
+        }
+
+        int spawnDelay = GsonHelper.getAsInt(json, "spawn_delay", 0);
+        if (spawnDelay < 0) {
+            throw new DungeonDataException("El spawn_delay no puede ser negativo para el mob " + entityType);
+        }
+
+        return new MobEntry(entityType, count, spawnDelay);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/model/PortalDef.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/PortalDef.java
@@ -1,0 +1,102 @@
+package com.tuempresa.rogue.data.model;
+
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.data.DungeonDataException;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+
+import java.util.Objects;
+
+/**
+ * Definition for a portal that allows players to access a dungeon.
+ */
+public final class PortalDef {
+    private final ResourceLocation id;
+    private final ResourceLocation dungeonId;
+    private final String displayName;
+    private final String description;
+    private final int requiredLevel;
+    private final int activationCost;
+
+    public PortalDef(ResourceLocation id,
+                     ResourceLocation dungeonId,
+                     String displayName,
+                     String description,
+                     int requiredLevel,
+                     int activationCost) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.dungeonId = Objects.requireNonNull(dungeonId, "dungeonId");
+        this.displayName = displayName;
+        this.description = description;
+        this.requiredLevel = requiredLevel;
+        this.activationCost = activationCost;
+    }
+
+    public ResourceLocation id() {
+        return id;
+    }
+
+    public ResourceLocation dungeonId() {
+        return dungeonId;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public int requiredLevel() {
+        return requiredLevel;
+    }
+
+    public int activationCost() {
+        return activationCost;
+    }
+
+    public static PortalDef fromJson(ResourceLocation fileId, JsonObject json) {
+        ResourceLocation id = parseResource(json, "id", fileId);
+        ResourceLocation dungeonId = parseResource(json, "dungeon");
+        String displayName = normalizeText(GsonHelper.getAsString(json, "display_name", id.toString()));
+        String description = normalizeText(GsonHelper.getAsString(json, "description", ""));
+        int requiredLevel = GsonHelper.getAsInt(json, "required_level", 0);
+        int activationCost = GsonHelper.getAsInt(json, "activation_cost", 0);
+
+        if (requiredLevel < 0) {
+            throw new DungeonDataException("El portal " + id + " tiene required_level negativo");
+        }
+        if (activationCost < 0) {
+            throw new DungeonDataException("El portal " + id + " tiene activation_cost negativo");
+        }
+        if (displayName.isBlank()) {
+            throw new DungeonDataException("El portal " + id + " requiere un display_name no vacío");
+        }
+
+        return new PortalDef(id, dungeonId, displayName, description, requiredLevel, activationCost);
+    }
+
+    private static ResourceLocation parseResource(JsonObject json, String field) {
+        if (!json.has(field)) {
+            throw new DungeonDataException("Falta el campo obligatorio '" + field + "'");
+        }
+        return parseResource(json, field, null);
+    }
+
+    private static ResourceLocation parseResource(JsonObject json, String field, ResourceLocation fallback) {
+        String raw = GsonHelper.getAsString(json, field, fallback != null ? fallback.toString() : null);
+        if (raw == null) {
+            throw new DungeonDataException("Falta el campo obligatorio '" + field + "'");
+        }
+        ResourceLocation id = ResourceLocation.tryParse(raw);
+        if (id == null) {
+            throw new DungeonDataException("El valor '" + raw + "' del campo '" + field + "' no es un identificador válido");
+        }
+        return id;
+    }
+
+    private static String normalizeText(String text) {
+        return text == null ? "" : text.trim();
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/model/RewardsDef.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/RewardsDef.java
@@ -1,0 +1,55 @@
+package com.tuempresa.rogue.data.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.data.DungeonDataException;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Rewards granted after completing a dungeon.
+ */
+public final class RewardsDef {
+    private final int experience;
+    private final List<ResourceLocation> lootTables;
+
+    public RewardsDef(int experience, List<ResourceLocation> lootTables) {
+        this.experience = experience;
+        this.lootTables = Collections.unmodifiableList(new ArrayList<>(lootTables));
+    }
+
+    public int experience() {
+        return experience;
+    }
+
+    public List<ResourceLocation> lootTables() {
+        return lootTables;
+    }
+
+    public static RewardsDef fromJson(JsonObject json) {
+        int experience = GsonHelper.getAsInt(json, "experience", 0);
+        if (experience < 0) {
+            throw new DungeonDataException("El valor de experience no puede ser negativo");
+        }
+
+        List<ResourceLocation> lootTables = new ArrayList<>();
+        if (json.has("loot_tables")) {
+            JsonArray array = GsonHelper.getAsJsonArray(json, "loot_tables");
+            for (JsonElement element : array) {
+                String rawId = element.getAsString();
+                ResourceLocation id = ResourceLocation.tryParse(rawId);
+                if (id == null) {
+                    throw new DungeonDataException("Loot table inválida: " + rawId);
+                }
+                lootTables.add(id);
+            }
+        }
+
+        return new RewardsDef(experience, lootTables);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/model/RoomDef.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/RoomDef.java
@@ -1,0 +1,56 @@
+package com.tuempresa.rogue.data.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.data.DungeonDataException;
+import net.minecraft.util.GsonHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Definition of a dungeon room composed of multiple waves.
+ */
+public final class RoomDef {
+    private final String id;
+    private final List<WaveDef> waves;
+
+    public RoomDef(String id, List<WaveDef> waves) {
+        this.id = id;
+        this.waves = Collections.unmodifiableList(new ArrayList<>(waves));
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public List<WaveDef> waves() {
+        return waves;
+    }
+
+    public static RoomDef fromJson(JsonObject json) {
+        String id = GsonHelper.getAsString(json, "id").trim();
+        if (id.isEmpty()) {
+            throw new DungeonDataException("Cada sala requiere un id no vacío");
+        }
+
+        if (!json.has("waves")) {
+            throw new DungeonDataException("La sala " + id + " debe definir waves");
+        }
+
+        JsonArray wavesArray = GsonHelper.getAsJsonArray(json, "waves");
+        if (wavesArray.isEmpty()) {
+            throw new DungeonDataException("La sala " + id + " debe tener al menos una wave");
+        }
+
+        List<WaveDef> waves = new ArrayList<>();
+        for (JsonElement element : wavesArray) {
+            JsonObject waveObj = GsonHelper.convertToJsonObject(element, "wave");
+            waves.add(WaveDef.fromJson(waveObj));
+        }
+
+        return new RoomDef(id, waves);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/model/WaveDef.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/WaveDef.java
@@ -1,0 +1,67 @@
+package com.tuempresa.rogue.data.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.data.DungeonDataException;
+import net.minecraft.util.GsonHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A wave within a dungeon room.
+ */
+public final class WaveDef {
+    private final int index;
+    private final int warmupTicks;
+    private final List<MobEntry> mobs;
+
+    public WaveDef(int index, int warmupTicks, List<MobEntry> mobs) {
+        this.index = index;
+        this.warmupTicks = warmupTicks;
+        this.mobs = Collections.unmodifiableList(new ArrayList<>(mobs));
+    }
+
+    public int index() {
+        return index;
+    }
+
+    public int warmupTicks() {
+        return warmupTicks;
+    }
+
+    public List<MobEntry> mobs() {
+        return mobs;
+    }
+
+    public static WaveDef fromJson(JsonObject json) {
+        int index = GsonHelper.getAsInt(json, "index");
+        if (index <= 0) {
+            throw new DungeonDataException("Cada wave necesita un index positivo");
+        }
+
+        int warmupTicks = GsonHelper.getAsInt(json, "warmup_ticks", 0);
+        if (warmupTicks < 0) {
+            throw new DungeonDataException("El warmup_ticks no puede ser negativo para la wave " + index);
+        }
+
+        if (!json.has("mobs")) {
+            throw new DungeonDataException("La wave " + index + " requiere una lista de mobs");
+        }
+
+        JsonArray mobsArray = GsonHelper.getAsJsonArray(json, "mobs");
+        if (mobsArray.isEmpty()) {
+            throw new DungeonDataException("La wave " + index + " debe definir al menos un mob");
+        }
+
+        List<MobEntry> mobs = new ArrayList<>();
+        for (JsonElement element : mobsArray) {
+            JsonObject mobObject = GsonHelper.convertToJsonObject(element, "mob");
+            mobs.add(MobEntry.fromJson(mobObject));
+        }
+
+        return new WaveDef(index, warmupTicks, mobs);
+    }
+}


### PR DESCRIPTION
## Summary
- add validated data models for portals, dungeons, rooms, waves, mobs, and rewards
- implement a resource reload listener that loads dungeon JSON definitions and exposes them to the mod
- register a /rogue reload command and hook the listener into the reload event bus

## Testing
- `./gradlew build` *(fails: script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dc40baba3c8326830d21d57a5d2f76