### PR TITLE
Add rogue hub and dungeon dimensions with teleport utilities

### DIFF
--- a/src/main/java/com/tuempresa/rogue/RogueMod.java
+++ b/src/main/java/com/tuempresa/rogue/RogueMod.java
@@ -2,6 +2,7 @@ package com.tuempresa.rogue;
 
 import com.mojang.logging.LogUtils;
 import com.tuempresa.rogue.data.DungeonDataReloader;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.common.Mod;
 import org.slf4j.Logger;
 
@@ -17,5 +18,15 @@ public final class RogueMod {
 
     public RogueMod() {
         LOGGER.info("Inicializando el mod {}", MOD_ID);
+    }
+
+    /**
+     * Crea un {@link ResourceLocation} dentro del espacio de nombres del mod.
+     *
+     * @param path el identificador relativo dentro del mod
+     * @return la {@link ResourceLocation} resultante
+     */
+    public static ResourceLocation id(String path) {
+        return ResourceLocation.fromNamespaceAndPath(MOD_ID, path);
     }
 }

--- a/src/main/java/com/tuempresa/rogue/world/RogueDimensions.java
+++ b/src/main/java/com/tuempresa/rogue/world/RogueDimensions.java
@@ -1,0 +1,43 @@
+package com.tuempresa.rogue.world;
+
+import com.tuempresa.rogue.RogueMod;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.dimension.LevelStem;
+
+/**
+ * Static references to the custom dimensions used by the mod. The actual
+ * layout of these dimensions is defined through JSON data packs, but having
+ * strongly typed keys on the Java side simplifies teleportation and world
+ * management code.
+ */
+public final class RogueDimensions {
+    /** Hub dimension identifier: {@code rogue:city1}. */
+    public static final ResourceKey<Level> CITY1_LEVEL =
+        ResourceKey.create(Registries.DIMENSION, RogueMod.id("city1"));
+
+    /** Dungeon dimension identifier: {@code rogue:earth_dim}. */
+    public static final ResourceKey<Level> EARTH_DUNGEON_LEVEL =
+        ResourceKey.create(Registries.DIMENSION, RogueMod.id("earth_dim"));
+
+    /** Level stem key for the hub dimension, useful during world creation. */
+    public static final ResourceKey<LevelStem> CITY1_LEVEL_STEM =
+        ResourceKey.create(Registries.LEVEL_STEM, RogueMod.id("city1"));
+
+    /** Level stem key for the dungeon dimension. */
+    public static final ResourceKey<LevelStem> EARTH_DUNGEON_LEVEL_STEM =
+        ResourceKey.create(Registries.LEVEL_STEM, RogueMod.id("earth_dim"));
+
+    /** Dimension type key for the hub dimension. */
+    public static final ResourceKey<DimensionType> HUB_DIMENSION_TYPE =
+        ResourceKey.create(Registries.DIMENSION_TYPE, RogueMod.id("hub"));
+
+    /** Dimension type key for the dungeon dimension. */
+    public static final ResourceKey<DimensionType> DUNGEON_DIMENSION_TYPE =
+        ResourceKey.create(Registries.DIMENSION_TYPE, RogueMod.id("dungeon"));
+
+    private RogueDimensions() {
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/world/TeleportUtil.java
+++ b/src/main/java/com/tuempresa/rogue/world/TeleportUtil.java
@@ -1,0 +1,69 @@
+package com.tuempresa.rogue.world;
+
+import com.tuempresa.rogue.RogueMod;
+import java.util.Optional;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Helper methods that simplify teleporting players between the custom
+ * dimensions exposed by the mod. They perform the common lookup logic and
+ * handle intra-dimensional teleportation with the correct networking calls.
+ */
+public final class TeleportUtil {
+    private TeleportUtil() {
+    }
+
+    /**
+     * Retrieves the server level associated with the supplied key.
+     *
+     * @param server the active Minecraft server
+     * @param levelKey the level key to look up
+     * @return an optional containing the server level if it is loaded
+     */
+    public static Optional<ServerLevel> level(MinecraftServer server, ResourceKey<Level> levelKey) {
+        return Optional.ofNullable(server.getLevel(levelKey));
+    }
+
+    /**
+     * Teleports the player to the requested block position inside the given
+     * level while preserving their current rotation.
+     */
+    public static void teleport(ServerPlayer player, ResourceKey<Level> levelKey, BlockPos position) {
+        teleport(player, levelKey, Vec3.atCenterOf(position), player.getYRot(), player.getXRot());
+    }
+
+    /**
+     * Teleports the player to the requested coordinates, changing dimensions
+     * if necessary.
+     *
+     * @param player the player that should be moved
+     * @param levelKey the destination level key
+     * @param targetPosition the exact destination coordinates
+     * @param yaw the horizontal rotation that should be applied on arrival
+     * @param pitch the vertical rotation that should be applied on arrival
+     */
+    public static void teleport(ServerPlayer player, ResourceKey<Level> levelKey, Vec3 targetPosition, float yaw, float pitch) {
+        MinecraftServer server = player.server;
+        if (server == null) {
+            throw new IllegalStateException("No se pudo acceder al servidor para teletransportar al jugador");
+        }
+
+        ServerLevel targetLevel = server.getLevel(levelKey);
+        if (targetLevel == null) {
+            throw new IllegalArgumentException("Nivel no encontrado para la dimensión " + levelKey.location());
+        }
+
+        if (player.level().dimension() == levelKey) {
+            player.connection.teleport(targetPosition.x(), targetPosition.y(), targetPosition.z(), yaw, pitch);
+        } else {
+            RogueMod.LOGGER.debug("Teletransportando a {} hacia {} en {}", player.getScoreboardName(), targetPosition, levelKey.location());
+            player.teleportTo(targetLevel, targetPosition.x(), targetPosition.y(), targetPosition.z(), yaw, pitch);
+        }
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/world/WorldBorderUtil.java
+++ b/src/main/java/com/tuempresa/rogue/world/WorldBorderUtil.java
@@ -1,0 +1,65 @@
+package com.tuempresa.rogue.world;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.border.WorldBorder;
+
+/**
+ * Utility helpers focused on configuring world borders. They provide the most
+ * common operations required by the mod when preparing dungeon runs.
+ */
+public final class WorldBorderUtil {
+    private static final double DEFAULT_DIAMETER = 5.9999968E7D;
+    private static final double DEFAULT_DAMAGE_PER_BLOCK = 0.2D;
+    private static final double DEFAULT_DAMAGE_BUFFER = 5.0D;
+    private static final int DEFAULT_WARNING_BLOCKS = 5;
+    private static final int DEFAULT_WARNING_TIME = 15;
+
+    private WorldBorderUtil() {
+    }
+
+    /**
+     * Configures a world border using a center position and diameter.
+     *
+     * @param level level that owns the world border
+     * @param centerX X coordinate for the border center
+     * @param centerZ Z coordinate for the border center
+     * @param diameter size of the border in blocks
+     */
+    public static void configure(ServerLevel level, double centerX, double centerZ, double diameter) {
+        configure(level, centerX, centerZ, diameter, DEFAULT_DAMAGE_PER_BLOCK, DEFAULT_DAMAGE_BUFFER);
+    }
+
+    /**
+     * Configures a world border with extended parameters.
+     */
+    public static void configure(ServerLevel level, double centerX, double centerZ, double diameter,
+                                 double damagePerBlock, double damageBuffer) {
+        WorldBorder border = level.getWorldBorder();
+        border.setCenter(centerX, centerZ);
+        border.setSize(diameter);
+        border.setDamagePerBlock(damagePerBlock);
+        border.setDamageSafeZone(damageBuffer);
+    }
+
+    /**
+     * Adjusts the warning configuration for a world border.
+     */
+    public static void setWarnings(ServerLevel level, int warningBlocks, int warningTimeSeconds) {
+        WorldBorder border = level.getWorldBorder();
+        border.setWarningBlocks(warningBlocks);
+        border.setWarningTime(warningTimeSeconds);
+    }
+
+    /**
+     * Restores vanilla defaults to the world border of the provided level.
+     */
+    public static void reset(ServerLevel level) {
+        WorldBorder border = level.getWorldBorder();
+        border.setCenter(0.0D, 0.0D);
+        border.setSize(DEFAULT_DIAMETER);
+        border.setDamagePerBlock(DEFAULT_DAMAGE_PER_BLOCK);
+        border.setDamageSafeZone(DEFAULT_DAMAGE_BUFFER);
+        border.setWarningBlocks(DEFAULT_WARNING_BLOCKS);
+        border.setWarningTime(DEFAULT_WARNING_TIME);
+    }
+}

--- a/src/main/resources/data/rogue/dimension/city1.json
+++ b/src/main/resources/data/rogue/dimension/city1.json
@@ -1,0 +1,12 @@
+{
+  "type": "rogue:hub",
+  "generator": {
+    "type": "minecraft:noise",
+    "seed": 0,
+    "settings": "minecraft:overworld",
+    "biome_source": {
+      "type": "minecraft:fixed",
+      "biome": "minecraft:plains"
+    }
+  }
+}

--- a/src/main/resources/data/rogue/dimension/earth_dim.json
+++ b/src/main/resources/data/rogue/dimension/earth_dim.json
@@ -1,0 +1,12 @@
+{
+  "type": "rogue:dungeon",
+  "generator": {
+    "type": "minecraft:noise",
+    "seed": 0,
+    "settings": "minecraft:nether",
+    "biome_source": {
+      "type": "minecraft:fixed",
+      "biome": "minecraft:deep_dark"
+    }
+  }
+}

--- a/src/main/resources/data/rogue/dimension_type/dungeon.json
+++ b/src/main/resources/data/rogue/dimension_type/dungeon.json
@@ -1,0 +1,20 @@
+{
+  "ambient_light": 0.15,
+  "bed_works": false,
+  "coordinate_scale": 1.0,
+  "effects": "minecraft:the_nether",
+  "fixed_time": 18000,
+  "has_ceiling": true,
+  "has_raids": false,
+  "has_skylight": false,
+  "height": 384,
+  "infiniburn": "minecraft:infiniburn_nether",
+  "logical_height": 384,
+  "min_y": -64,
+  "monster_spawn_block_light_limit": 15,
+  "monster_spawn_light_level": 0,
+  "natural": false,
+  "piglin_safe": false,
+  "respawn_anchor_works": true,
+  "ultrawarm": false
+}

--- a/src/main/resources/data/rogue/dimension_type/hub.json
+++ b/src/main/resources/data/rogue/dimension_type/hub.json
@@ -1,0 +1,25 @@
+{
+  "ambient_light": 0.0,
+  "bed_works": true,
+  "coordinate_scale": 1.0,
+  "effects": "minecraft:overworld",
+  "has_ceiling": false,
+  "has_raids": true,
+  "has_skylight": true,
+  "height": 384,
+  "infiniburn": "minecraft:infiniburn_overworld",
+  "logical_height": 384,
+  "min_y": -64,
+  "monster_spawn_block_light_limit": 0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": {
+      "max_inclusive": 7,
+      "min_inclusive": 0
+    }
+  },
+  "natural": true,
+  "piglin_safe": false,
+  "respawn_anchor_works": false,
+  "ultrawarm": false
+}


### PR DESCRIPTION
## Summary
- add resource keys and data definitions for the rogue:city1 hub and rogue:earth_dim dungeon dimensions
- introduce teleportation and world border utility helpers for moving players and configuring arenas
- expose a helper for creating mod-scoped resource locations

## Testing
- not run (`./gradlew build` missing gradle wrapper)


------
https://chatgpt.com/codex/tasks/task_e_68dc4257a7b483269249a76df71ecab1