### PR TITLE
Add portal activation system

### DIFF
--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonInstance.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonInstance.java
@@ -1,0 +1,33 @@
+package com.tuempresa.rogue.dungeon;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Represents a running dungeon instance and keeps track of its party members.
+ */
+public final class DungeonInstance {
+    private final ResourceLocation dungeonId;
+    private final Set<UUID> members = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    DungeonInstance(ResourceLocation dungeonId) {
+        this.dungeonId = dungeonId;
+    }
+
+    public ResourceLocation dungeonId() {
+        return dungeonId;
+    }
+
+    public Set<UUID> members() {
+        return Collections.unmodifiableSet(members);
+    }
+
+    void addPlayer(ServerPlayer player) {
+        members.add(player.getUUID());
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
@@ -1,0 +1,32 @@
+package com.tuempresa.rogue.dungeon;
+
+import com.tuempresa.rogue.data.model.PortalDef;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Keeps track of active dungeon instances and ensures players are grouped in
+ * a deterministic fashion when entering through a portal.
+ */
+public final class DungeonManager {
+    private static final DungeonManager INSTANCE = new DungeonManager();
+
+    private final Map<ResourceLocation, DungeonInstance> activeInstances = new ConcurrentHashMap<>();
+
+    private DungeonManager() {
+    }
+
+    public static DungeonInstance createOrJoin(ServerPlayer player, PortalDef portal) {
+        return INSTANCE.createOrJoinInternal(player, portal);
+    }
+
+    private DungeonInstance createOrJoinInternal(ServerPlayer player, PortalDef portal) {
+        ResourceLocation dungeonId = portal.dungeonId();
+        DungeonInstance instance = activeInstances.computeIfAbsent(dungeonId, DungeonInstance::new);
+        instance.addPlayer(player);
+        return instance;
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/portal/PortalBlock.java
+++ b/src/main/java/com/tuempresa/rogue/portal/PortalBlock.java
@@ -1,0 +1,45 @@
+package com.tuempresa.rogue.portal;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+/**
+ * Simple block that delegates interaction handling to {@link PortalSystem}.
+ */
+public class PortalBlock extends Block {
+    private final ResourceLocation portalId;
+
+    public PortalBlock(BlockBehaviour.Properties properties, ResourceLocation portalId) {
+        super(properties);
+        this.portalId = portalId;
+    }
+
+    @Override
+    public InteractionResult use(BlockState state,
+                                 Level level,
+                                 BlockPos pos,
+                                 Player player,
+                                 InteractionHand hand,
+                                 BlockHitResult hit) {
+        if (level.isClientSide) {
+            return InteractionResult.SUCCESS;
+        }
+        if (!(player instanceof ServerPlayer serverPlayer)) {
+            return InteractionResult.PASS;
+        }
+        return PortalSystem.get().activatePortal(serverPlayer, portalId);
+    }
+
+    public ResourceLocation portalId() {
+        return portalId;
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/portal/PortalSystem.java
+++ b/src/main/java/com/tuempresa/rogue/portal/PortalSystem.java
@@ -1,0 +1,83 @@
+package com.tuempresa.rogue.portal;
+
+import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.data.model.PortalDef;
+import com.tuempresa.rogue.dungeon.DungeonInstance;
+import com.tuempresa.rogue.dungeon.DungeonManager;
+import com.tuempresa.rogue.economy.Economy;
+import com.tuempresa.rogue.world.RogueDimensions;
+import com.tuempresa.rogue.world.TeleportUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Centralises the interaction logic for dungeon portals. It validates portal
+ * definitions, checks player requirements, deducts gold and finally
+ * teleports the player to the configured dungeon dimension.
+ */
+public final class PortalSystem {
+    private static final PortalSystem INSTANCE = new PortalSystem();
+
+    private PortalSystem() {
+    }
+
+    public static PortalSystem get() {
+        return INSTANCE;
+    }
+
+    public InteractionResult activatePortal(ServerPlayer player, ResourceLocation portalId) {
+        PortalDef portalDef = findPortal(portalId);
+        if (portalDef == null) {
+            player.sendSystemMessage(Component.literal("Este portal no está configurado."));
+            return InteractionResult.FAIL;
+        }
+
+        int playerLevel = player.experienceLevel;
+        if (playerLevel < portalDef.requiredLevel()) {
+            player.sendSystemMessage(Component.literal(
+                "Necesitas nivel " + portalDef.requiredLevel() + " para entrar en " + portalDef.displayName() + "."));
+            return InteractionResult.FAIL;
+        }
+
+        int entryCost = portalDef.activationCost();
+        if (entryCost > 0 && !Economy.hasGold(player, entryCost)) {
+            player.sendSystemMessage(Component.literal(
+                "Necesitas " + entryCost + " de oro para activar este portal."));
+            return InteractionResult.FAIL;
+        }
+
+        if (entryCost > 0 && !Economy.takeGold(player, entryCost)) {
+            player.sendSystemMessage(Component.literal("No se pudo descontar el oro necesario."));
+            return InteractionResult.FAIL;
+        }
+
+        DungeonInstance instance = DungeonManager.createOrJoin(player, portalDef);
+        RogueMod.LOGGER.debug("{} se unió a la instancia {} del portal {}", player.getGameProfile().getName(),
+            instance.dungeonId(), portalDef.id());
+
+        MinecraftServer server = player.serverLevel().getServer();
+        Optional<ServerLevel> level = TeleportUtil.level(server, RogueDimensions.EARTH_DUNGEON_LEVEL);
+        if (level.isEmpty()) {
+            player.sendSystemMessage(Component.literal("La dimensión del portal no está disponible."));
+            return InteractionResult.FAIL;
+        }
+
+        BlockPos spawn = level.get().getSharedSpawnPos();
+        TeleportUtil.teleport(player, RogueDimensions.EARTH_DUNGEON_LEVEL, spawn);
+        player.sendSystemMessage(Component.literal("Has activado el portal hacia " + portalDef.displayName() + "."));
+        return InteractionResult.SUCCESS;
+    }
+
+    private PortalDef findPortal(ResourceLocation portalId) {
+        Map<ResourceLocation, PortalDef> portals = RogueMod.DUNGEON_DATA.portals();
+        return portals.get(portalId);
+    }
+}


### PR DESCRIPTION
## Summary
- add a PortalSystem that validates portal requirements, charges gold, joins a dungeon instance, and teleports players into earth_dim
- introduce a PortalBlock that routes player interaction to the shared portal logic
- scaffold DungeonManager/DungeonInstance to keep track of active dungeon runs

## Testing
- `./gradlew build` *(fails: Gradle wrapper is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dc56da2df08326b3231d9042253eb6