### PR TITLE
Add dungeon run lifecycle management

### DIFF
--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
@@ -1,20 +1,28 @@
 package com.tuempresa.rogue.dungeon;
 
+import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.data.model.DungeonDef;
 import com.tuempresa.rogue.data.model.PortalDef;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Keeps track of active dungeon instances and ensures players are grouped in
- * a deterministic fashion when entering through a portal.
+ * Keeps track of active dungeon runs and ensures players are grouped in a
+ * deterministic fashion when entering through a portal.
  */
+@Mod.EventBusSubscriber(modid = RogueMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class DungeonManager {
     private static final DungeonManager INSTANCE = new DungeonManager();
 
-    private final Map<ResourceLocation, DungeonInstance> activeInstances = new ConcurrentHashMap<>();
+    private final Map<ResourceLocation, DungeonRun> activeRuns = new ConcurrentHashMap<>();
 
     private DungeonManager() {
     }
@@ -25,8 +33,41 @@ public final class DungeonManager {
 
     private DungeonInstance createOrJoinInternal(ServerPlayer player, PortalDef portal) {
         ResourceLocation dungeonId = portal.dungeonId();
-        DungeonInstance instance = activeInstances.computeIfAbsent(dungeonId, DungeonInstance::new);
-        instance.addPlayer(player);
-        return instance;
+        DungeonDef dungeonDef = RogueMod.DUNGEON_DATA.dungeons().get(dungeonId);
+        if (dungeonDef == null) {
+            throw new IllegalStateException("No existe la definición de la mazmorra " + dungeonId);
+        }
+
+        DungeonRun run = activeRuns.compute(dungeonId, (id, existing) -> {
+            DungeonRun current = existing;
+            if (current == null || current.isComplete()) {
+                current = new DungeonRun(new DungeonInstance(id), dungeonDef);
+            }
+            current.join(player);
+            return current;
+        });
+
+        if (run == null) {
+            throw new IllegalStateException("No se pudo crear la instancia para la mazmorra " + dungeonId);
+        }
+
+        return run.instance();
+    }
+
+    private void tick(MinecraftServer server) {
+        Iterator<Map.Entry<ResourceLocation, DungeonRun>> iterator = activeRuns.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<ResourceLocation, DungeonRun> entry = iterator.next();
+            DungeonRun run = entry.getValue();
+            if (run.tick(server)) {
+                RogueMod.LOGGER.debug("Finalizada la instancia de la mazmorra {}", entry.getKey());
+                iterator.remove();
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(ServerTickEvent.Post event) {
+        INSTANCE.tick(event.getServer());
     }
 }

--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonRun.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonRun.java
@@ -1,0 +1,169 @@
+package com.tuempresa.rogue.dungeon;
+
+import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.data.model.DungeonDef;
+import com.tuempresa.rogue.data.model.MobEntry;
+import com.tuempresa.rogue.data.model.RoomDef;
+import com.tuempresa.rogue.data.model.WaveDef;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Encapsula el estado de una partida activa dentro de una mazmorra concreta.
+ * Gestiona la sala actual, los temporizadores de las waves y los jugadores
+ * vivos para que {@link DungeonManager} pueda avanzar la partida en cada tick
+ * del servidor.
+ */
+final class DungeonRun {
+    private final DungeonInstance instance;
+    private final DungeonDef dungeon;
+    private final Set<UUID> alivePlayers = new HashSet<>();
+    private final Queue<ScheduledSpawn> pendingSpawns = new PriorityQueue<>(Comparator.comparingLong(ScheduledSpawn::triggerTick));
+
+    private int currentRoomIndex;
+    private int currentWaveIndex;
+    private RoomDef currentRoom;
+    private WaveDef currentWave;
+    private int warmupTimer;
+    private boolean exhaustedContent;
+    private long tickCounter;
+
+    DungeonRun(DungeonInstance instance, DungeonDef dungeon) {
+        this.instance = Objects.requireNonNull(instance, "instance");
+        this.dungeon = Objects.requireNonNull(dungeon, "dungeon");
+        this.currentRoomIndex = 0;
+        this.currentWaveIndex = 0;
+        this.warmupTimer = 0;
+        this.tickCounter = 0L;
+    }
+
+    DungeonInstance instance() {
+        return instance;
+    }
+
+    void join(ServerPlayer player) {
+        instance.addPlayer(player);
+        alivePlayers.add(player.getUUID());
+    }
+
+    boolean isComplete() {
+        return exhaustedContent && pendingSpawns.isEmpty() && currentWave == null;
+    }
+
+    boolean tick(MinecraftServer server) {
+        tickCounter++;
+        refreshAlivePlayers(server);
+        if (alivePlayers.isEmpty()) {
+            RogueMod.LOGGER.debug("Finalizando mazmorra {}: no quedan jugadores vivos", dungeon.id());
+            return true;
+        }
+
+        if (!exhaustedContent && currentWave == null) {
+            prepareNextWave();
+        }
+
+        if (currentWave != null) {
+            if (warmupTimer > 0) {
+                warmupTimer--;
+            }
+            if (warmupTimer <= 0) {
+                triggerWaveSpawn();
+            }
+        }
+
+        processPendingSpawns();
+        return isComplete();
+    }
+
+    private void refreshAlivePlayers(MinecraftServer server) {
+        Set<UUID> currentlyAlive = new HashSet<>();
+        for (UUID memberId : instance.members()) {
+            ServerPlayer member = server.getPlayerList().getPlayer(memberId);
+            if (member != null && member.isAlive()) {
+                currentlyAlive.add(memberId);
+            }
+        }
+
+        alivePlayers.clear();
+        alivePlayers.addAll(currentlyAlive);
+    }
+
+    private void prepareNextWave() {
+        if (exhaustedContent) {
+            return;
+        }
+
+        if (currentRoom == null) {
+            if (currentRoomIndex >= dungeon.rooms().size()) {
+                exhaustedContent = true;
+                return;
+            }
+
+            currentRoom = dungeon.rooms().get(currentRoomIndex);
+            currentWaveIndex = 0;
+            RogueMod.LOGGER.debug("Iniciando sala {} de la mazmorra {}", currentRoom.id(), dungeon.id());
+        }
+
+        if (currentWaveIndex >= currentRoom.waves().size()) {
+            currentRoomIndex++;
+            currentRoom = null;
+            prepareNextWave();
+            return;
+        }
+
+        currentWave = currentRoom.waves().get(currentWaveIndex++);
+        warmupTimer = currentWave.warmupTicks();
+        RogueMod.LOGGER.debug("Preparando wave {} (warmup {} ticks) en sala {}", currentWave.index(), warmupTimer,
+            currentRoom.id());
+    }
+
+    private void triggerWaveSpawn() {
+        WaveDef wave = currentWave;
+        if (wave == null) {
+            return;
+        }
+
+        RogueMod.LOGGER.debug("Programando aparición de wave {} en la sala {} (mazmorra {})", wave.index(),
+            currentRoom != null ? currentRoom.id() : "desconocida", dungeon.id());
+
+        for (MobEntry mob : wave.mobs()) {
+            for (int i = 0; i < mob.count(); i++) {
+                long triggerTick = tickCounter + mob.spawnDelay();
+                pendingSpawns.add(new ScheduledSpawn(mob.entityType(), triggerTick, wave.index()));
+            }
+        }
+
+        currentWave = null;
+    }
+
+    private void processPendingSpawns() {
+        while (!pendingSpawns.isEmpty() && pendingSpawns.peek().triggerTick() <= tickCounter) {
+            ScheduledSpawn spawn = pendingSpawns.poll();
+            if (spawn == null) {
+                continue;
+            }
+
+            RogueMod.LOGGER.debug(
+                "[{}] Spawn ficticio del mob {} en la wave {}",
+                dungeon.id(),
+                spawn.entityType(),
+                spawn.waveIndex());
+        }
+
+        if (pendingSpawns.isEmpty() && exhaustedContent && currentWave == null) {
+            RogueMod.LOGGER.debug("Mazmorra {} completada", dungeon.id());
+        }
+    }
+
+    private record ScheduledSpawn(ResourceLocation entityType, long triggerTick, int waveIndex) {
+    }
+}


### PR DESCRIPTION
## Summary
- create `DungeonRun` to track room progression, warmup timers, alive players, and scheduled mob spawns
- update `DungeonManager` to manage active runs, subscribe to `ServerTickEvent`, and clean up finished instances

## Testing
- not run (Gradle wrapper script `./gradlew` is not present)


------
https://chatgpt.com/codex/tasks/task_e_68dc59f177408326919e58137bd85d30