### PR TITLE
Block untagged natural spawns in earth dungeon

### DIFF
--- a/src/main/java/com/tuempresa/rogue/world/RogueEntityTypeTags.java
+++ b/src/main/java/com/tuempresa/rogue/world/RogueEntityTypeTags.java
@@ -1,0 +1,19 @@
+package com.tuempresa.rogue.world;
+
+import com.tuempresa.rogue.RogueMod;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EntityType;
+
+/**
+ * Colección de llaves de tags utilizadas por el mod. Mantenerlas centralizadas
+ * evita duplicar cadenas mágicas y reduce errores tipográficos.
+ */
+public final class RogueEntityTypeTags {
+    /** Tag de tipos de entidad permitidos para spawns naturales en las mazmorras. */
+    public static final TagKey<EntityType<?>> ROGUE_MOBS =
+        TagKey.create(Registries.ENTITY_TYPE, RogueMod.id("rogue_mob"));
+
+    private RogueEntityTypeTags() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a central entity-type tag constant for rogue mobs
- cancel natural spawns in the earth dungeon dimension if the mob type lacks the rogue_mob tag

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc5bedb1fc8326a0b52d9100510d29