### PR TITLE
Implement dungeon progression cleanup and rewards

### DIFF
--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonMobEvents.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonMobEvents.java
@@ -1,0 +1,39 @@
+package com.tuempresa.rogue.dungeon;
+
+import com.tuempresa.rogue.RogueMod;
+import net.minecraft.world.entity.Mob;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.entity.living.LivingDeathEvent;
+
+import java.util.UUID;
+
+/**
+ * Maneja los eventos de vida/muerte de los mobs pertenecientes a una partida
+ * de mazmorra para actualizar el progreso de las salas.
+ */
+@Mod.EventBusSubscriber(modid = RogueMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+final class DungeonMobEvents {
+    private static final String TAG_RUN_ID = "RogueRunId";
+
+    private DungeonMobEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onMobDeath(LivingDeathEvent event) {
+        if (!(event.getEntity() instanceof Mob mob)) {
+            return;
+        }
+
+        if (!mob.getTags().contains("rogue_mob")) {
+            return;
+        }
+
+        if (!mob.getPersistentData().contains(TAG_RUN_ID)) {
+            return;
+        }
+
+        UUID runId = mob.getPersistentData().getUUID(TAG_RUN_ID);
+        DungeonManager.onMobDefeated(runId, mob.getUUID());
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/dungeon/RewardSystem.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/RewardSystem.java
@@ -1,0 +1,84 @@
+package com.tuempresa.rogue.dungeon;
+
+import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.economy.Economy;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Sistema encargado de repartir las recompensas al completar una mazmorra.
+ */
+final class RewardSystem {
+    private static final int GOLD_MIN = 70;
+    private static final int GOLD_MAX = 100;
+    private static final int FRAGMENT_MIN = 1;
+    private static final int FRAGMENT_MAX = 2;
+    private static final double COSMETIC_CHANCE = 0.05D;
+    private static final ResourceLocation ROCK_FRAGMENT_ID = RogueMod.id("rock_fragment");
+    private static final ResourceLocation COSMETIC_TOKEN_ID = RogueMod.id("cosmetic_token");
+
+    private RewardSystem() {
+    }
+
+    static void grantVictoryRewards(MinecraftServer server, DungeonRun run) {
+        RandomSource random = RandomSource.create();
+        for (UUID memberId : run.instance().members()) {
+            ServerPlayer player = server.getPlayerList().getPlayer(memberId);
+            if (player == null) {
+                continue;
+            }
+
+            int gold = random.nextIntBetweenInclusive(GOLD_MIN, GOLD_MAX);
+            Economy.giveGold(player, gold);
+
+            giveRockFragments(player, random);
+            maybeGiveCosmetic(player, random);
+
+            player.sendSystemMessage(Component.literal("Recompensas de mazmorra: +" + gold + " de oro."));
+        }
+    }
+
+    private static void giveRockFragments(ServerPlayer player, RandomSource random) {
+        Item fragmentItem = resolveItem(ROCK_FRAGMENT_ID).orElse(Items.AMETHYST_SHARD);
+        int amount = random.nextIntBetweenInclusive(FRAGMENT_MIN, FRAGMENT_MAX);
+        if (amount <= 0) {
+            return;
+        }
+
+        ItemStack stack = new ItemStack(fragmentItem, amount);
+        giveItem(player, stack);
+        player.sendSystemMessage(Component.literal("Has recibido " + amount + " Fragmentos de Roca."));
+    }
+
+    private static void maybeGiveCosmetic(ServerPlayer player, RandomSource random) {
+        if (random.nextDouble() >= COSMETIC_CHANCE) {
+            return;
+        }
+
+        Item cosmeticItem = resolveItem(COSMETIC_TOKEN_ID).orElse(Items.NAME_TAG);
+        ItemStack stack = new ItemStack(cosmeticItem);
+        giveItem(player, stack);
+        player.sendSystemMessage(Component.literal("¡Suerte! Obtienes un cosmético especial."));
+    }
+
+    private static Optional<Item> resolveItem(ResourceLocation id) {
+        return BuiltInRegistries.ITEM.getOptional(id);
+    }
+
+    private static void giveItem(ServerPlayer player, ItemStack stack) {
+        boolean added = player.addItem(stack);
+        if (!added) {
+            player.drop(stack, false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track dungeon run mobs to detect room clearance, teleport the party to subsequent rooms, and finish runs cleanly
- add a reward system that grants gold, rock fragments, and a cosmetic chance on victory while cleaning up entities on completion
- listen for dungeon mob deaths to keep active counts in sync during each run

## Testing
- gradle build *(fails: plugin net.neoforged.gradle:7.0.109 is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6126e3d483268342ad154a5422e1