### PR TITLE
Add QA commands and configurable rogue settings

### DIFF
--- a/src/main/java/com/tuempresa/rogue/RogueEvents.java
+++ b/src/main/java/com/tuempresa/rogue/RogueEvents.java
@@ -2,8 +2,10 @@ package com.tuempresa.rogue;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.tuempresa.rogue.config.RogueConfig;
 import com.tuempresa.rogue.data.DungeonDataException;
 import com.tuempresa.rogue.data.DungeonDataReloader;
+import com.tuempresa.rogue.dungeon.DungeonManager;
 import com.tuempresa.rogue.economy.Economy;
 import com.tuempresa.rogue.world.RogueDimensions;
 import com.tuempresa.rogue.world.RogueEntityTypeTags;
@@ -14,12 +16,16 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.entity.living.MobSpawnEvent;
+
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Handles Forge level events such as command registration and data reload listeners.
@@ -53,7 +59,15 @@ public final class RogueEvents {
                     .then(Commands.argument("jugador", EntityArgument.player())
                         .executes(context -> getGold(
                             context.getSource(),
-                            EntityArgument.getPlayer(context, "jugador")))))));
+                            EntityArgument.getPlayer(context, "jugador"))))))
+            .then(Commands.literal("runs")
+                .then(Commands.literal("list")
+                    .executes(context -> listRuns(context.getSource()))))
+            .then(Commands.literal("warp")
+                .then(Commands.argument("sala", IntegerArgumentType.integer(0))
+                    .executes(context -> warpToRoom(
+                        context.getSource(),
+                        IntegerArgumentType.getInteger(context, "sala"))))));
     }
 
     @SubscribeEvent
@@ -68,10 +82,12 @@ public final class RogueEvents {
 
         Mob mob = event.getEntity();
         if (!mob.getType().is(RogueEntityTypeTags.ROGUE_MOBS)) {
-            RogueMod.LOGGER.debug(
-                "Cancelando spawn natural de {} en {} por falta de tag",
-                mob.getType(),
-                event.getLevel().dimension().location());
+            if (RogueConfig.logSpawnLifecycle()) {
+                RogueMod.LOGGER.debug(
+                    "Cancelando spawn natural de {} en {} por falta de tag",
+                    mob.getType(),
+                    event.getLevel().dimension().location());
+            }
             event.setResult(Event.Result.DENY);
         }
     }
@@ -109,5 +125,58 @@ public final class RogueEvents {
             target.getDisplayName().getString() + " tiene " + total + " de oro."),
             false);
         return total;
+    }
+
+    private static int listRuns(CommandSourceStack source) {
+        List<DungeonManager.RunInfo> runs = DungeonManager.listRuns();
+        if (runs.isEmpty()) {
+            source.sendSuccess(() -> Component.literal("No hay runs activos."), false);
+            return 0;
+        }
+
+        source.sendSuccess(() -> Component.literal("Runs activos: " + runs.size()), false);
+        for (DungeonManager.RunInfo info : runs) {
+            String roomLabel = info.currentRoomId() != null ? info.currentRoomId() : "#" + info.currentRoomIndex();
+            String status;
+            if (info.exhausted()) {
+                status = "finalizada";
+            } else if (info.waitingRoomClear()) {
+                status = "limpieza";
+            } else {
+                status = "combate";
+            }
+
+            String message = String.format(
+                "- %s (%s) sala %d [%s] jugadores %d/%d estado=%s",
+                shortRunId(info.runId()),
+                info.dungeonId(),
+                info.currentRoomIndex(),
+                roomLabel,
+                info.alivePlayers(),
+                info.totalMembers(),
+                status);
+            source.sendSuccess(() -> Component.literal(message), false);
+        }
+        return runs.size();
+    }
+
+    private static int warpToRoom(CommandSourceStack source, int roomIndex) throws CommandSyntaxException {
+        ServerPlayer player = source.getPlayerOrException();
+        boolean warped = DungeonManager.warpPlayerToRoom(player, roomIndex);
+        if (!warped) {
+            source.sendFailure(Component.literal("No estás en una mazmorra activa."));
+            return 0;
+        }
+
+        Component message = Component.literal("Teletransportado a la sala " + roomIndex + ".");
+        player.sendSystemMessage(message);
+        source.sendSuccess(() -> message, false);
+        return 1;
+    }
+
+    private static String shortRunId(UUID runId) {
+        String full = runId.toString();
+        int idx = full.indexOf('-');
+        return idx > 0 ? full.substring(0, idx) : full;
     }
 }

--- a/src/main/java/com/tuempresa/rogue/RogueMod.java
+++ b/src/main/java/com/tuempresa/rogue/RogueMod.java
@@ -1,9 +1,12 @@
 package com.tuempresa.rogue;
 
 import com.mojang.logging.LogUtils;
+import com.tuempresa.rogue.config.RogueConfig;
 import com.tuempresa.rogue.data.DungeonDataReloader;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
+import net.neoforged.fml.ModLoadingContext;
 import org.slf4j.Logger;
 
 /**
@@ -17,6 +20,7 @@ public final class RogueMod {
     public static final DungeonDataReloader DUNGEON_DATA = DungeonDataReloader.getInstance();
 
     public RogueMod() {
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, RogueConfig.COMMON_SPEC, "rogue-common.toml");
         LOGGER.info("Inicializando el mod {}", MOD_ID);
     }
 

--- a/src/main/java/com/tuempresa/rogue/config/RogueConfig.java
+++ b/src/main/java/com/tuempresa/rogue/config/RogueConfig.java
@@ -1,0 +1,76 @@
+package com.tuempresa.rogue.config;
+
+import net.neoforged.fml.config.ModConfigSpec;
+
+/**
+ * Centraliza la configuración común del mod y expone accesos convenientes
+ * para los subsistemas que dependen de parámetros ajustables.
+ */
+public final class RogueConfig {
+    public static final ModConfigSpec COMMON_SPEC;
+    public static final Common COMMON;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        COMMON = new Common(builder);
+        COMMON_SPEC = builder.build();
+    }
+
+    private RogueConfig() {
+    }
+
+    public static Common common() {
+        return COMMON;
+    }
+
+    public static int roomClearThresholdTicks() {
+        return Math.max(1, COMMON.roomClearThresholdTicks.get());
+    }
+
+    public static int roomSpacingBlocks() {
+        return Math.max(1, COMMON.roomSpacingBlocks.get());
+    }
+
+    public static boolean logRunLifecycle() {
+        return COMMON.logRunLifecycle.get();
+    }
+
+    public static boolean logRoomLifecycle() {
+        return COMMON.logRoomLifecycle.get();
+    }
+
+    public static boolean logSpawnLifecycle() {
+        return COMMON.logSpawnLifecycle.get();
+    }
+
+    public static final class Common {
+        final ModConfigSpec.IntValue roomClearThresholdTicks;
+        final ModConfigSpec.IntValue roomSpacingBlocks;
+        final ModConfigSpec.BooleanValue logRunLifecycle;
+        final ModConfigSpec.BooleanValue logRoomLifecycle;
+        final ModConfigSpec.BooleanValue logSpawnLifecycle;
+
+        Common(ModConfigSpec.Builder builder) {
+            builder.comment("Parámetros generales de las mazmorras").push("dungeons");
+            roomClearThresholdTicks = builder
+                .comment("Ticks consecutivos necesarios para marcar una sala como despejada.")
+                .defineInRange("roomClearThresholdTicks", 40, 1, 20_000);
+            roomSpacingBlocks = builder
+                .comment("Separación en bloques entre salas consecutivas dentro de la dimensión de mazmorras.")
+                .defineInRange("roomSpacingBlocks", 20, 1, 512);
+            builder.pop();
+
+            builder.comment("Control de verbosidad de logs").push("logs");
+            logRunLifecycle = builder
+                .comment("Registra eventos de inicio/fin de partidas en el log de depuración.")
+                .define("logRunLifecycle", true);
+            logRoomLifecycle = builder
+                .comment("Registra transiciones de salas y limpieza de habitaciones en el log de depuración.")
+                .define("logRoomLifecycle", true);
+            logSpawnLifecycle = builder
+                .comment("Registra los detalles de aparición de waves y mobs en el log de depuración.")
+                .define("logSpawnLifecycle", false);
+            builder.pop();
+        }
+    }
+}

--- a/src/main/resources/rogue-common.toml
+++ b/src/main/resources/rogue-common.toml
@@ -1,0 +1,17 @@
+# Configuración por defecto para el mod Rogue.
+# Este archivo define los parámetros clave utilizados para las partidas de mazmorras
+# y los toggles de logging orientados a QA.
+
+[dungeons]
+# Ticks consecutivos necesarios para considerar que una sala está completamente despejada.
+roomClearThresholdTicks = 40
+# Separación en bloques entre salas consecutivas dentro de la dimensión de mazmorras.
+roomSpacingBlocks = 20
+
+[logs]
+# Registra eventos de inicio y fin de runs en el log de depuración.
+logRunLifecycle = true
+# Registra transiciones de salas y mensajes de limpieza.
+logRoomLifecycle = true
+# Registra detalles de warmup y spawns de mobs.
+logSpawnLifecycle = false


### PR DESCRIPTION
## Summary
- add QA-centric `/rogue runs list` and `/rogue warp <sala>` commands while reusing reload and gold management utilities
- expose active run metadata and targeted warps via the dungeon manager and run internals
- introduce a shared `rogue-common.toml` config with adjustable dungeon parameters and logging toggles, wiring it into the mod bootstrap

## Testing
- Not run (Gradle wrapper is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_e_68dc64aeb1ac83268339bb4da2d86f15