### PR TITLE
Build void dungeon rooms and constrain dungeon mobs

### DIFF
--- a/src/main/resources/data/rogue/dimension/earth_dim.json
+++ b/src/main/resources/data/rogue/dimension/earth_dim.json
@@ -1,12 +1,22 @@
 {
   "type": "rogue:dungeon",
   "generator": {
-    "type": "minecraft:noise",
-    "seed": 0,
-    "settings": "minecraft:nether",
-    "biome_source": {
-      "type": "minecraft:fixed",
-      "biome": "minecraft:deep_dark"
+    "type": "minecraft:flat",
+    "settings": {
+      "biome": "minecraft:deep_dark",
+      "lakes": false,
+      "features": false,
+      "structure_overrides": [],
+      "layers": [
+        {
+          "block": "minecraft:air",
+          "height": 64
+        },
+        {
+          "block": "minecraft:smooth_stone",
+          "height": 1
+        }
+      ]
     }
   }
 }

--- a/src/main/resources/data/rogue/dungeons/earth_portal.json
+++ b/src/main/resources/data/rogue/dungeons/earth_portal.json
@@ -1,0 +1,118 @@
+{
+  "portal": {
+    "id": "rogue:earth_portal",
+    "dungeon": "rogue:earth_catacombs",
+    "display_name": "Portal de Tierra",
+    "description": "Un antiguo portal hacia las catacumbas de tierra.",
+    "required_level": 1,
+    "activation_cost": 50
+  },
+  "dungeon": {
+    "id": "rogue:earth_catacombs",
+    "display_name": "Mazmorra de Tierra I",
+    "rooms": [
+      {
+        "id": "earth_entry",
+        "waves": [
+          {
+            "index": 1,
+            "warmup_ticks": 40,
+            "mobs": [
+              {
+                "type": "minecraft:zombie",
+                "count": 3,
+                "spawn_delay": 0
+              },
+              {
+                "type": "minecraft:skeleton",
+                "count": 2,
+                "spawn_delay": 20
+              }
+            ]
+          },
+          {
+            "index": 2,
+            "warmup_ticks": 60,
+            "mobs": [
+              {
+                "type": "minecraft:husk",
+                "count": 2,
+                "spawn_delay": 0
+              },
+              {
+                "type": "minecraft:spider",
+                "count": 1,
+                "spawn_delay": 40
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "earth_depths",
+        "waves": [
+          {
+            "index": 1,
+            "warmup_ticks": 40,
+            "mobs": [
+              {
+                "type": "minecraft:zombie_villager",
+                "count": 2,
+                "spawn_delay": 0
+              },
+              {
+                "type": "minecraft:cave_spider",
+                "count": 2,
+                "spawn_delay": 30
+              }
+            ]
+          },
+          {
+            "index": 2,
+            "warmup_ticks": 80,
+            "mobs": [
+              {
+                "type": "minecraft:drowned",
+                "count": 3,
+                "spawn_delay": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "earth_core",
+        "waves": [
+          {
+            "index": 1,
+            "warmup_ticks": 60,
+            "mobs": [
+              {
+                "type": "minecraft:husk",
+                "count": 4,
+                "spawn_delay": 0
+              }
+            ]
+          },
+          {
+            "index": 2,
+            "warmup_ticks": 100,
+            "mobs": [
+              {
+                "type": "minecraft:warden",
+                "count": 1,
+                "spawn_delay": 40
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "rewards": {
+      "experience": 250,
+      "loot_tables": [
+        "minecraft:chests/simple_dungeon"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- switch the Earth dungeon dimension to a flat void preset with a smooth stone floor at Y=64
- procedurally construct closed dungeon rooms, cache their bounds, and spawn mobs only on valid ground within them
- add a watchdog that returns dungeon mobs to the room anchor when they leave their allowed area or lose footing

## Testing
- not run (gradle wrapper not present in repository)


------
https://chatgpt.com/codex/tasks/task_e_68dc68fd0aec8326af0d90eecf1afce1