### PR TITLE
Add wind affinity weapon and earth mob tags

### DIFF
--- a/src/main/resources/data/rogue/tags/entity_types/affinity/earth.json
+++ b/src/main/resources/data/rogue/tags/entity_types/affinity/earth.json
@@ -1,4 +1,13 @@
 {
   "replace": false,
-  "values": []
+  "values": [
+    "minecraft:zombie",
+    "minecraft:skeleton",
+    "minecraft:husk",
+    "minecraft:spider",
+    "minecraft:zombie_villager",
+    "minecraft:cave_spider",
+    "minecraft:drowned",
+    "minecraft:warden"
+  ]
 }

--- a/src/main/resources/data/rogue/tags/items/affinity/wind.json
+++ b/src/main/resources/data/rogue/tags/items/affinity/wind.json
@@ -1,4 +1,6 @@
 {
   "replace": false,
-  "values": []
+  "values": [
+    "minecraft:trident"
+  ]
 }


### PR DESCRIPTION
## Summary
- tag the trident as a wind affinity weapon
- mark the earth dungeon mobs with the earth affinity entity tag

## Testing
- Not run (validation requires in-game testing)

------
https://chatgpt.com/codex/tasks/task_e_68dc77362a448326a4dd3b71d3935f7b