### PR TITLE
Implement dungeon wave management and failure triggers

### DIFF
--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
@@ -31,6 +31,10 @@ public final class DungeonManager {
         return Optional.ofNullable(runsById.get(runId));
     }
 
+    public static Optional<DungeonRun> findRunByPlayer(UUID playerId) {
+        return runsById.values().stream().filter(run -> run.hasMember(playerId)).findFirst();
+    }
+
     public static List<RunInfo> listRuns() {
         List<RunInfo> info = new ArrayList<>();
         runsById.values().forEach(run -> info.add(new RunInfo(run.getId(), run.getDef().id(), run.getParty().size(), run.isVictory())));

--- a/src/main/java/com/tuempresa/rogue/dungeon/room/RoomState.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/room/RoomState.java
@@ -5,12 +5,19 @@ import com.tuempresa.rogue.util.AABBUtil;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.phys.AABB;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 public final class RoomState {
     private final RoomDef def;
     private final AABB bounds;
     private final RandomSource random = RandomSource.create();
+    private final Set<UUID> mobs = new HashSet<>();
     private int alive;
     private int nextWaveAt;
+    private boolean started;
+    private boolean cleared;
 
     public RoomState(RoomDef def) {
         this.def = def;
@@ -33,19 +40,59 @@ public final class RoomState {
         return alive;
     }
 
-    public void setAlive(int alive) {
-        this.alive = alive;
-    }
-
     public int getNextWaveAt() {
         return nextWaveAt;
     }
 
-    public void scheduleNextWave(int ticks) {
-        this.nextWaveAt = ticks;
+    public void scheduleNextWave(int absoluteTick) {
+        this.nextWaveAt = absoluteTick;
     }
 
     public boolean hasPlayersInside() {
         return alive > 0;
+    }
+
+    public boolean isStarted() {
+        return started;
+    }
+
+    public boolean isCleared() {
+        return cleared;
+    }
+
+    public boolean isWaveReady(int currentTick) {
+        return !cleared && currentTick >= nextWaveAt;
+    }
+
+    public void registerMob(UUID mobId) {
+        mobs.add(mobId);
+        alive = mobs.size();
+        started = true;
+        cleared = false;
+    }
+
+    public void unregisterMob(UUID mobId) {
+        if (mobs.remove(mobId)) {
+            alive = mobs.size();
+            if (alive <= 0) {
+                cleared = true;
+            }
+        }
+    }
+
+    public void resetState(int currentTick) {
+        mobs.clear();
+        alive = 0;
+        nextWaveAt = currentTick;
+        started = false;
+        cleared = false;
+    }
+
+    public void clearTracked() {
+        mobs.clear();
+        alive = 0;
+        cleared = false;
+        started = false;
+        nextWaveAt = 0;
     }
 }

--- a/src/main/java/com/tuempresa/rogue/portal/PortalSystem.java
+++ b/src/main/java/com/tuempresa/rogue/portal/PortalSystem.java
@@ -39,7 +39,7 @@ public final class PortalSystem {
         DungeonRun run = DungeonManager.createOrJoin(def, player);
         ResourceKey<Level> levelKey = ResourceKey.create(Registries.DIMENSION, def.world());
         TP.toSpawn(player, levelKey);
-        run.spawnWave();
+        run.spawnWave(player.server);
         Chat.success(player, "Entrando a " + def.id());
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/com/tuempresa/rogue/spawn/SpawnSystem.java
+++ b/src/main/java/com/tuempresa/rogue/spawn/SpawnSystem.java
@@ -1,40 +1,126 @@
 package com.tuempresa.rogue.spawn;
 
-import com.tuempresa.rogue.data.model.DungeonDef;
 import com.tuempresa.rogue.data.model.MobEntry;
+import com.tuempresa.rogue.data.model.WaveDef;
+import com.tuempresa.rogue.dungeon.instance.DungeonRun;
 import com.tuempresa.rogue.dungeon.room.RoomState;
+import com.tuempresa.rogue.util.AABBUtil;
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 public final class SpawnSystem {
     private SpawnSystem() {
     }
 
-    public static void spawnWave(ServerLevel level, RoomState state, DungeonDef def) {
-        state.setAlive(state.getAlive() + 1);
+    public static void spawnWave(ServerLevel level, DungeonRun run, RoomState state, int roomIndex) {
+        WaveDef wave = state.getDef().wave();
+        if (wave == null) {
+            return;
+        }
+
+        int missing = Math.max(0, wave.maxAlive() - state.getAlive());
+        if (missing <= 0) {
+            return;
+        }
+
+        RandomSource random = state.getRandom();
+        for (int i = 0; i < missing; i++) {
+            MobEntry entry = pickWeighted(wave.packs(), random);
+            if (entry == null) {
+                continue;
+            }
+            Optional<Mob> optionalMob = spawnMob(level, entry, state, random);
+            optionalMob.ifPresent(mob -> {
+                mob.setPersistenceRequired();
+                applyTags(mob, "rogue_dungeon", "rogue_run:" + run.getId());
+                String affinity = state.getDef().affinityTag();
+                if (!affinity.isBlank()) {
+                    applyTags(mob, "affinity:" + affinity);
+                }
+                scaleStatsByParty(mob, run.getParty().size());
+                level.addFreshEntity(mob);
+                run.registerMob(mob.getUUID(), roomIndex);
+            });
+        }
     }
 
-    public static MobEntry pickWeighted(MobEntry[] entries) {
-        return entries.length > 0 ? entries[0] : null;
+    public static MobEntry pickWeighted(List<MobEntry> entries, RandomSource random) {
+        if (entries.isEmpty()) {
+            return null;
+        }
+        int totalWeight = entries.stream().mapToInt(MobEntry::weight).sum();
+        if (totalWeight <= 0) {
+            return entries.get(0);
+        }
+        int roll = random.nextInt(totalWeight);
+        int cumulative = 0;
+        for (MobEntry entry : entries) {
+            cumulative += entry.weight();
+            if (roll < cumulative) {
+                return entry;
+            }
+        }
+        return entries.get(entries.size() - 1);
     }
 
-    public static Optional<Mob> spawnMob(ServerLevel level, MobEntry entry) {
+    public static Optional<Mob> spawnMob(ServerLevel level, MobEntry entry, RoomState state, RandomSource random) {
         EntityType<?> type = EntityType.byString(entry.id().toString()).orElse(null);
         if (type instanceof EntityType<? extends Mob> mobType) {
-            return Optional.ofNullable(mobType.create(level));
+            Mob mob = mobType.create(level);
+            if (mob == null) {
+                return Optional.empty();
+            }
+            BlockPos pos = AABBUtil.randomPosInside(state.getBounds(), random);
+            mob.moveTo(pos.getX() + 0.5D, pos.getY(), pos.getZ() + 0.5D, random.nextFloat() * 360.0F, 0.0F);
+            mob.finalizeSpawn(level, level.getCurrentDifficultyAt(pos), net.minecraft.world.entity.MobSpawnType.EVENT, null);
+            if (!entry.nbt().isEmpty()) {
+                mob.readAdditionalSaveData(entry.nbt().copy());
+            }
+            return Optional.of(mob);
         }
         return Optional.empty();
     }
 
     public static void applyTags(Mob mob, String... tags) {
         for (String tag : tags) {
-            mob.addTag(tag);
+            if (tag != null && !tag.isBlank()) {
+                mob.addTag(tag);
+            }
         }
     }
 
     public static void scaleStatsByParty(Mob mob, int partySize) {
+        if (partySize <= 1) {
+            return;
+        }
+        double multiplier = 1.0D + 0.25D * (partySize - 1);
+        AttributeInstance maxHealth = mob.getAttribute(Attributes.MAX_HEALTH);
+        if (maxHealth != null) {
+            maxHealth.setBaseValue(maxHealth.getBaseValue() * multiplier);
+            mob.setHealth((float) maxHealth.getValue());
+        }
+        AttributeInstance attack = mob.getAttribute(Attributes.ATTACK_DAMAGE);
+        if (attack != null) {
+            attack.setBaseValue(attack.getBaseValue() * multiplier);
+        }
+    }
+
+    public static void cleanup(ServerLevel level, Set<UUID> mobs) {
+        mobs.forEach(id -> {
+            var entity = level.getEntity(id);
+            if (entity != null) {
+                entity.discard();
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add wave scheduling, room progression, and timeout handling to dungeon runs
- implement mob spawning with tagging, scaling, and cleanup plus physical exit portal creation
- trigger dungeon failure on party deaths and keep mob counts in sync via death tracking

## Testing
- Not run (gradlew script missing)


------
https://chatgpt.com/codex/tasks/task_e_68ddcf51575c8326b481722035383102