### PR TITLE
Improve warp behavior for dungeon rooms

### DIFF
--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonManager.java
@@ -2,9 +2,19 @@ package com.tuempresa.rogue.dungeon;
 
 import com.tuempresa.rogue.data.model.DungeonDef;
 import com.tuempresa.rogue.dungeon.instance.DungeonRun;
+import com.tuempresa.rogue.dungeon.room.RoomState;
+import com.tuempresa.rogue.util.AABBUtil;
+import com.tuempresa.rogue.util.TP;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,14 +68,76 @@ public final class DungeonManager {
     }
 
     public static boolean warpPlayerToRoom(ServerPlayer player, String roomId) {
-        for (DungeonRun run : runsById.values()) {
-            if (!run.getParty().contains(player.getUUID())) {
+        if (player.server == null) {
+            return false;
+        }
+
+        Optional<DungeonRun> runOptional = findRunByPlayer(player.getUUID());
+        if (runOptional.isEmpty()) {
+            return false;
+        }
+
+        DungeonRun run = runOptional.get();
+        RoomState room = run.findRoomById(roomId);
+        if (room == null) {
+            return false;
+        }
+
+        ResourceKey<Level> levelKey = ResourceKey.create(Registries.DIMENSION, run.getDef().world());
+        ServerLevel level = player.server.getLevel(levelKey);
+        if (level == null) {
+            return false;
+        }
+
+        AABB bounds = room.getBounds();
+        for (int attempt = 0; attempt < 20; attempt++) {
+            BlockPos candidate = AABBUtil.randomPosInside(bounds, room.getRandom());
+            if (!isValidTeleportPosition(level, candidate)) {
                 continue;
             }
-            run.returnToCity(player);
+            teleportPlayer(player, levelKey, candidate);
             return true;
         }
+
+        BlockPos fallback = findFirstValidPosition(level, bounds);
+        if (fallback != null) {
+            teleportPlayer(player, levelKey, fallback);
+            return true;
+        }
+
         return false;
+    }
+
+    private static boolean isValidTeleportPosition(ServerLevel level, BlockPos pos) {
+        BlockPos below = pos.below();
+        return !level.isEmptyBlock(below) && level.isEmptyBlock(pos) && level.isEmptyBlock(pos.above());
+    }
+
+    private static BlockPos findFirstValidPosition(ServerLevel level, AABB bounds) {
+        int minX = (int) Math.floor(bounds.minX);
+        int maxX = (int) Math.ceil(bounds.maxX);
+        int minY = (int) Math.floor(bounds.minY);
+        int maxY = (int) Math.ceil(bounds.maxY);
+        int minZ = (int) Math.floor(bounds.minZ);
+        int maxZ = (int) Math.ceil(bounds.maxZ);
+
+        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
+        for (int y = maxY - 1; y >= minY; y--) {
+            for (int x = minX; x < maxX; x++) {
+                for (int z = minZ; z < maxZ; z++) {
+                    mutable.set(x, y, z);
+                    if (isValidTeleportPosition(level, mutable)) {
+                        return mutable.immutable();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static void teleportPlayer(ServerPlayer player, ResourceKey<Level> levelKey, BlockPos pos) {
+        Vec3 target = new Vec3(pos.getX() + 0.5D, pos.getY(), pos.getZ() + 0.5D);
+        TP.to(player, levelKey, target);
     }
 
     public static void onServerTick(MinecraftServer server) {

--- a/src/main/java/com/tuempresa/rogue/dungeon/instance/DungeonRun.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/instance/DungeonRun.java
@@ -67,6 +67,18 @@ public final class DungeonRun {
         return rooms.get(currentRoomIndex);
     }
 
+    public RoomState findRoomById(String roomId) {
+        if (roomId == null || roomId.isBlank()) {
+            return null;
+        }
+        for (RoomState room : rooms) {
+            if (roomId.equals(room.getDef().id())) {
+                return room;
+            }
+        }
+        return null;
+    }
+
     public void addMember(ServerPlayer player) {
         party.add(player.getUUID());
     }


### PR DESCRIPTION
## Summary
- locate the player's active run when warping and search for the requested room state
- teleport players to valid positions within the target room's bounds instead of returning to the city
- add a helper on DungeonRun to expose room lookups by identifier

## Testing
- gradle build *(fails: Plugin [id: 'net.neoforged.gradle', version: '7.0.109'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd2a4d0108326ba097b0c98508362