### PR TITLE
Add shop buy command for purchasing items

### DIFF
--- a/src/main/java/com/tuempresa/rogue/core/RogueCommandEvents.java
+++ b/src/main/java/com/tuempresa/rogue/core/RogueCommandEvents.java
@@ -6,6 +6,7 @@ import com.tuempresa.rogue.core.command.RogueDataCommand;
 import com.tuempresa.rogue.core.command.RogueGoldCommand;
 import com.tuempresa.rogue.core.command.RogueRunsCommand;
 import com.tuempresa.rogue.core.command.RogueWarpCommand;
+import com.tuempresa.rogue.core.command.RogueShopCommand;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -24,5 +25,6 @@ public final class RogueCommandEvents {
         RogueConfigCommand.register(root);
 
         event.getDispatcher().register(root);
+        RogueShopCommand.register(event.getDispatcher());
     }
 }

--- a/src/main/java/com/tuempresa/rogue/core/command/RogueShopCommand.java
+++ b/src/main/java/com/tuempresa/rogue/core/command/RogueShopCommand.java
@@ -1,0 +1,91 @@
+package com.tuempresa.rogue.core.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.CommandDispatcher;
+import com.tuempresa.rogue.economy.Economy;
+import java.util.Locale;
+import java.util.Map;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public final class RogueShopCommand {
+    private static final Map<String, ShopItem> SHOP_ITEMS = Map.of(
+        "varita_rapida", new ShopItem("Varita Rápida", 120, Items.BLAZE_ROD),
+        "arco_pesado", new ShopItem("Arco Pesado", 120, Items.BOW),
+        "armadura_ligera", new ShopItem("Armadura Ligera", 150, Items.LEATHER_CHESTPLATE),
+        "armadura_reforzada", new ShopItem("Armadura Reforzada", 150, Items.IRON_CHESTPLATE)
+    );
+
+    private RogueShopCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(buildRoot());
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> buildRoot() {
+        return Commands.literal("shop")
+            .then(Commands.literal("buy")
+                .then(Commands.argument("itemId", StringArgumentType.word())
+                    .suggests((context, builder) -> SharedSuggestionProvider.suggest(SHOP_ITEMS.keySet(), builder))
+                    .executes(RogueShopCommand::buy)));
+    }
+
+    private static int buy(CommandContext<CommandSourceStack> context) {
+        ServerPlayer player;
+        try {
+            player = context.getSource().getPlayerOrException();
+        } catch (Exception exception) {
+            context.getSource().sendFailure(Component.literal("Solo los jugadores pueden usar este comando."));
+            return 0;
+        }
+
+        String rawId = StringArgumentType.getString(context, "itemId");
+        String itemId = rawId.toLowerCase(Locale.ROOT);
+        ShopItem shopItem = SHOP_ITEMS.get(itemId);
+
+        if (shopItem == null) {
+            context.getSource().sendFailure(Component.literal("Artículo desconocido: " + rawId));
+            return 0;
+        }
+
+        if (!Economy.hasGold(player, shopItem.price())) {
+            context.getSource().sendFailure(Component.literal("No tienes suficiente oro. Precio: " + shopItem.price()));
+            return 0;
+        }
+
+        if (!Economy.takeGold(player, shopItem.price())) {
+            context.getSource().sendFailure(Component.literal("No se pudo completar la compra."));
+            return 0;
+        }
+
+        ItemStack stack = shopItem.createStack();
+        if (!player.addItem(stack)) {
+            player.drop(stack, false);
+        }
+
+        context.getSource().sendSuccess(
+            () -> Component.literal("Has comprado " + shopItem.displayName() + " por " + shopItem.price() + " de oro."),
+            false
+        );
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private record ShopItem(String displayName, int price, Item item) {
+        private ItemStack createStack() {
+            ItemStack stack = new ItemStack(item);
+            stack.setHoverName(Component.literal(displayName));
+            return stack;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `/shop buy` command that validates item identifiers, charges the configured gold price, and gives the player the purchased item
- register the shop command during server command registration alongside the existing Rogue commands

## Testing
- gradle build *(fails: Plugin [id: 'net.neoforged.gradle'] not found in the container's limited repository configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e06577a4548326bf540c9d6888646c