### PR TITLE
Add basic combat items and expose item configs

### DIFF
--- a/src/main/java/com/tuempresa/rogue/RogueMod.java
+++ b/src/main/java/com/tuempresa/rogue/RogueMod.java
@@ -4,6 +4,7 @@ import com.tuempresa.rogue.config.RogueConfig;
 import com.tuempresa.rogue.core.RogueBlocks;
 import com.tuempresa.rogue.core.RogueCommandEvents;
 import com.tuempresa.rogue.core.RogueConstants;
+import com.tuempresa.rogue.core.RogueItems;
 import com.tuempresa.rogue.core.RogueLogger;
 import com.tuempresa.rogue.core.RogueServerEvents;
 import com.tuempresa.rogue.data.DungeonDataReloader;
@@ -32,6 +33,7 @@ public final class RogueMod {
         RogueLogger.info("Inicializando Rogue Mod");
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, RogueConfig.COMMON_SPEC, "rogue-common.toml");
         RogueBlocks.init();
+        RogueItems.init();
         WorldRegistry.registerDimensions();
         registerEvents();
         registerCommands();

--- a/src/main/java/com/tuempresa/rogue/core/RogueConstants.java
+++ b/src/main/java/com/tuempresa/rogue/core/RogueConstants.java
@@ -5,6 +5,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.Level;
 
 /**
@@ -24,6 +25,15 @@ public final class RogueConstants {
 
     public static final TagKey<EntityType<?>> TAG_EARTH =
         TagKey.create(Registries.ENTITY_TYPE, id("earth"));
+
+    public static final TagKey<Item> TAG_VARITAS =
+        TagKey.create(Registries.ITEM, id("varitas"));
+    public static final TagKey<Item> TAG_ARCOS =
+        TagKey.create(Registries.ITEM, id("arcos"));
+    public static final TagKey<Item> TAG_ARMADURAS_LIGERAS =
+        TagKey.create(Registries.ITEM, id("armaduras_ligeras"));
+    public static final TagKey<Item> TAG_ARMADURAS_REFORZADAS =
+        TagKey.create(Registries.ITEM, id("armaduras_reforzadas"));
 
     private RogueConstants() {
     }

--- a/src/main/java/com/tuempresa/rogue/core/RogueItems.java
+++ b/src/main/java/com/tuempresa/rogue/core/RogueItems.java
@@ -1,0 +1,40 @@
+package com.tuempresa.rogue.core;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.Item;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+/**
+ * Registro centralizado de ítems del mod.
+ */
+public final class RogueItems {
+    private RogueItems() {
+    }
+
+    public static final DeferredRegister<Item> ITEMS =
+        DeferredRegister.create(Registries.ITEM, RogueConstants.MOD_ID);
+
+    public static final DeferredHolder<Item, Item> VARITA_RAPIDA = ITEMS.register(
+        "varita_rapida",
+        () -> new Item(new Item.Properties()));
+
+    public static final DeferredHolder<Item, Item> ARCO_PESADO = ITEMS.register(
+        "arco_pesado",
+        () -> new Item(new Item.Properties()));
+
+    public static final DeferredHolder<Item, Item> ARMADURA_LIGERA = ITEMS.register(
+        "armadura_ligera",
+        () -> new Item(new Item.Properties()));
+
+    public static final DeferredHolder<Item, Item> ARMADURA_REFORZADA = ITEMS.register(
+        "armadura_reforzada",
+        () -> new Item(new Item.Properties()));
+
+    public static void init() {
+        IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+        ITEMS.register(modBus);
+    }
+}

--- a/src/main/resources/data/rogue/config/items/arco_pesado.json
+++ b/src/main/resources/data/rogue/config/items/arco_pesado.json
@@ -1,0 +1,4 @@
+{
+  "attackIntervalTicks": 24,
+  "baseDamage": 6
+}

--- a/src/main/resources/data/rogue/config/items/armadura_ligera.json
+++ b/src/main/resources/data/rogue/config/items/armadura_ligera.json
@@ -1,0 +1,4 @@
+{
+  "attackIntervalTicks": 20,
+  "baseDamage": 2
+}

--- a/src/main/resources/data/rogue/config/items/armadura_reforzada.json
+++ b/src/main/resources/data/rogue/config/items/armadura_reforzada.json
@@ -1,0 +1,4 @@
+{
+  "attackIntervalTicks": 32,
+  "baseDamage": 4
+}

--- a/src/main/resources/data/rogue/config/items/varita_rapida.json
+++ b/src/main/resources/data/rogue/config/items/varita_rapida.json
@@ -1,0 +1,4 @@
+{
+  "attackIntervalTicks": 16,
+  "baseDamage": 3
+}

--- a/src/main/resources/data/rogue/tags/items/arcos.json
+++ b/src/main/resources/data/rogue/tags/items/arcos.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rogue:arco_pesado"
+  ]
+}

--- a/src/main/resources/data/rogue/tags/items/armaduras_ligeras.json
+++ b/src/main/resources/data/rogue/tags/items/armaduras_ligeras.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rogue:armadura_ligera"
+  ]
+}

--- a/src/main/resources/data/rogue/tags/items/armaduras_reforzadas.json
+++ b/src/main/resources/data/rogue/tags/items/armaduras_reforzadas.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rogue:armadura_reforzada"
+  ]
+}

--- a/src/main/resources/data/rogue/tags/items/varitas.json
+++ b/src/main/resources/data/rogue/tags/items/varitas.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rogue:varita_rapida"
+  ]
+}


### PR DESCRIPTION
## Summary
- register the new combat equipment items and hook their registry into the mod bootstrap
- expose attack speed and damage values for each item through JSON configs
- add item tags that group the wand, bow, and armor categories

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e06742c0d0832696710bfed40d39b3