### PR TITLE
Add automatic projectile attacks for wand and heavy bow

### DIFF
--- a/src/main/java/com/tuempresa/rogue/RogueMod.java
+++ b/src/main/java/com/tuempresa/rogue/RogueMod.java
@@ -8,6 +8,7 @@ import com.tuempresa.rogue.core.RogueItems;
 import com.tuempresa.rogue.core.RogueLogger;
 import com.tuempresa.rogue.core.RogueServerEvents;
 import com.tuempresa.rogue.data.DungeonDataReloader;
+import com.tuempresa.rogue.data.ItemConfigReloader;
 import com.tuempresa.rogue.world.WorldRegistry;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
@@ -24,6 +25,7 @@ public final class RogueMod {
     public static final String MOD_ID = RogueConstants.MOD_ID;
     public static final org.slf4j.Logger LOGGER = RogueLogger.raw();
     public static final DungeonDataReloader DUNGEON_DATA = DungeonDataReloader.getInstance();
+    public static final ItemConfigReloader ITEM_CONFIGS = ItemConfigReloader.getInstance();
 
     public RogueMod() {
         init();

--- a/src/main/java/com/tuempresa/rogue/combat/AutoAttackSystem.java
+++ b/src/main/java/com/tuempresa/rogue/combat/AutoAttackSystem.java
@@ -1,0 +1,186 @@
+package com.tuempresa.rogue.combat;
+
+import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.core.RogueConstants;
+import com.tuempresa.rogue.data.model.ItemConfig;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.entity.projectile.Snowball;
+import net.minecraft.world.entity.projectile.Arrow;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.EntityHitResult;
+import net.neoforged.neoforge.event.entity.ProjectileImpactEvent;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Gestiona los autoataques de armas especiales configuradas vía data packs.
+ */
+public final class AutoAttackSystem {
+    private static final String TAG_AUTO_ATTACK = "RogueAutoAttack";
+    private static final String TAG_BASE_DAMAGE = "RogueAutoAttackBaseDamage";
+    private static final String PLAYER_AWAKENINGS_KEY = "rogue_awakenings_active";
+
+    private static final Map<UUID, AttackTracker> ATTACK_TRACKERS = new HashMap<>();
+
+    private AutoAttackSystem() {
+    }
+
+    public static void tick(MinecraftServer server) {
+        if (server == null) {
+            return;
+        }
+
+        Set<UUID> seen = new HashSet<>();
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            seen.add(player.getUUID());
+            handlePlayer(player);
+        }
+
+        ATTACK_TRACKERS.keySet().removeIf(id -> !seen.contains(id));
+    }
+
+    public static void handleImpact(ProjectileImpactEvent event) {
+        Projectile projectile = event.getProjectile();
+        Level level = projectile.level();
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
+        }
+
+        CompoundTag tag = projectile.getPersistentData();
+        if (!tag.getBoolean(TAG_AUTO_ATTACK)) {
+            return;
+        }
+
+        event.setCanceled(true);
+        projectile.discard();
+
+        if (!(event.getRayTraceResult() instanceof EntityHitResult entityHit)) {
+            return;
+        }
+
+        Entity hitEntity = entityHit.getEntity();
+        if (!(hitEntity instanceof LivingEntity living)) {
+            return;
+        }
+
+        float baseDamage = tag.getFloat(TAG_BASE_DAMAGE);
+        if (baseDamage <= 0.0F) {
+            return;
+        }
+
+        Entity owner = projectile.getOwner();
+        DamageSource source;
+        float totalDamage = baseDamage;
+        if (owner instanceof ServerPlayer player) {
+            int awakenings = Math.max(1, player.getPersistentData().getInt(PLAYER_AWAKENINGS_KEY));
+            totalDamage = baseDamage * awakenings;
+            source = serverLevel.damageSources().playerAttack(player);
+        } else {
+            source = serverLevel.damageSources().magic();
+        }
+
+        living.hurt(source, totalDamage);
+    }
+
+    private static void handlePlayer(ServerPlayer player) {
+        if (player.isSpectator() || player.isDeadOrDying()) {
+            ATTACK_TRACKERS.remove(player.getUUID());
+            return;
+        }
+
+        ItemStack stack = player.getMainHandItem();
+        if (stack.isEmpty() || (!stack.is(RogueConstants.TAG_VARITAS) && !stack.is(RogueConstants.TAG_ARCOS))) {
+            ATTACK_TRACKERS.remove(player.getUUID());
+            return;
+        }
+
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(stack.getItem());
+        Optional<ItemConfig> configOpt = RogueMod.ITEM_CONFIGS.get(itemId);
+        if (configOpt.isEmpty()) {
+            ATTACK_TRACKERS.remove(player.getUUID());
+            return;
+        }
+
+        ItemConfig config = configOpt.get();
+        AttackTracker tracker = ATTACK_TRACKERS.computeIfAbsent(player.getUUID(), id -> new AttackTracker());
+        tracker.updateItem(itemId);
+        if (tracker.shouldAttack(config.attackIntervalTicks())) {
+            fireProjectile(player, stack, config.baseDamage());
+        }
+    }
+
+    private static void fireProjectile(ServerPlayer player, ItemStack stack, float baseDamage) {
+        Level level = player.level();
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
+        }
+
+        Projectile projectile;
+        if (stack.is(RogueConstants.TAG_ARCOS)) {
+            projectile = createArrow(serverLevel, player);
+        } else {
+            projectile = createSnowball(serverLevel, player);
+        }
+
+        markProjectile(projectile, baseDamage);
+        serverLevel.addFreshEntity(projectile);
+    }
+
+    private static Projectile createArrow(ServerLevel level, ServerPlayer player) {
+        Arrow arrow = new Arrow(level, player);
+        arrow.pickup = AbstractArrow.Pickup.DISALLOWED;
+        arrow.setBaseDamage(0.0D);
+        arrow.shootFromRotation(player, player.getXRot(), player.getYRot(), 0.0F, 3.0F, 1.0F);
+        return arrow;
+    }
+
+    private static Projectile createSnowball(ServerLevel level, ServerPlayer player) {
+        Snowball snowball = new Snowball(level, player);
+        snowball.shootFromRotation(player, player.getXRot(), player.getYRot(), 0.0F, 1.5F, 0.5F);
+        return snowball;
+    }
+
+    private static void markProjectile(Projectile projectile, float baseDamage) {
+        CompoundTag tag = projectile.getPersistentData();
+        tag.putBoolean(TAG_AUTO_ATTACK, true);
+        tag.putFloat(TAG_BASE_DAMAGE, baseDamage);
+    }
+
+    private static final class AttackTracker {
+        private ResourceLocation currentItem;
+        private int cooldown;
+
+        void updateItem(ResourceLocation item) {
+            if (!item.equals(currentItem)) {
+                currentItem = item;
+                cooldown = 0;
+            }
+        }
+
+        boolean shouldAttack(int interval) {
+            if (cooldown > 0) {
+                cooldown--;
+                return false;
+            }
+
+            cooldown = Math.max(1, interval);
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/core/RogueServerEvents.java
+++ b/src/main/java/com/tuempresa/rogue/core/RogueServerEvents.java
@@ -1,6 +1,7 @@
 package com.tuempresa.rogue.core;
 
 import com.tuempresa.rogue.combat.AffinityUtil;
+import com.tuempresa.rogue.combat.AutoAttackSystem;
 import com.tuempresa.rogue.config.RogueConfig;
 import com.tuempresa.rogue.portal.PortalBlock;
 import com.tuempresa.rogue.util.RogueLogger;
@@ -13,12 +14,20 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
+import net.neoforged.neoforge.event.entity.ProjectileImpactEvent;
 import net.neoforged.neoforge.event.entity.living.LivingHurtEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
 
 public final class RogueServerEvents {
     @SubscribeEvent
     public void onAddReloadListeners(AddReloadListenerEvent event) {
         event.addListener(RogueMod.DUNGEON_DATA);
+        event.addListener(RogueMod.ITEM_CONFIGS);
+    }
+
+    @SubscribeEvent
+    public void onServerTick(ServerTickEvent.Post event) {
+        AutoAttackSystem.tick(event.getServer());
     }
 
     @SubscribeEvent
@@ -49,6 +58,11 @@ public final class RogueServerEvents {
         }
         float bonus = (float) RogueConfig.affinityBonusMultiplier();
         event.setAmount(event.getAmount() * (1.0F + bonus));
+    }
+
+    @SubscribeEvent
+    public void onProjectileImpact(ProjectileImpactEvent event) {
+        AutoAttackSystem.handleImpact(event);
     }
 
     private void ensureCityPortal(ServerLevel level) {

--- a/src/main/java/com/tuempresa/rogue/data/ItemConfigException.java
+++ b/src/main/java/com/tuempresa/rogue/data/ItemConfigException.java
@@ -1,0 +1,14 @@
+package com.tuempresa.rogue.data;
+
+/**
+ * Excepción dedicada para errores al cargar configuraciones de ítems.
+ */
+public class ItemConfigException extends RuntimeException {
+    public ItemConfigException(String message) {
+        super(message);
+    }
+
+    public ItemConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/ItemConfigReloader.java
+++ b/src/main/java/com/tuempresa/rogue/data/ItemConfigReloader.java
@@ -1,0 +1,81 @@
+package com.tuempresa.rogue.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.core.RogueConstants;
+import com.tuempresa.rogue.data.model.ItemConfig;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Reload listener responsible for parsing generic item configuration files.
+ */
+public final class ItemConfigReloader extends SimpleJsonResourceReloadListener {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final ItemConfigReloader INSTANCE = new ItemConfigReloader();
+
+    private Map<ResourceLocation, ItemConfig> itemConfigs = Map.of();
+
+    private ItemConfigReloader() {
+        super(GSON, "config/items");
+    }
+
+    public static ItemConfigReloader getInstance() {
+        return INSTANCE;
+    }
+
+    public Optional<ItemConfig> get(ResourceLocation itemId) {
+        return Optional.ofNullable(itemConfigs.get(itemId));
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> preparedData,
+                         ResourceManager resourceManager,
+                         ProfilerFiller profiler) {
+        Map<ResourceLocation, ItemConfig> configs = new HashMap<>();
+
+        preparedData.forEach((fileId, jsonElement) -> {
+            if (!RogueConstants.MOD_ID.equals(fileId.getNamespace())) {
+                return;
+            }
+
+            try {
+                JsonObject root = GsonHelper.convertToJsonObject(jsonElement, "root");
+                ItemConfig config = ItemConfig.fromJson(fileId, root);
+                configs.put(fileId, config);
+            } catch (ItemConfigException e) {
+                RogueMod.LOGGER.error("Fallo cargando configuración de ítem {}: {}", fileId, e.getMessage());
+            } catch (Exception e) {
+                RogueMod.LOGGER.error("Error inesperado cargando configuración de ítem {}: {}", fileId, e.getMessage());
+            }
+        });
+
+        itemConfigs = Collections.unmodifiableMap(configs);
+        RogueMod.LOGGER.info("Cargadas {} configuraciones de ítems", itemConfigs.size());
+    }
+
+    public void reloadNow(ResourceManager resourceManager) {
+        try {
+            Map<ResourceLocation, JsonElement> prepared = this.prepare(resourceManager, ProfilerFiller.EMPTY);
+            this.apply(prepared, resourceManager, ProfilerFiller.EMPTY);
+        } catch (Exception e) {
+            throw new ItemConfigException("Error recargando configuraciones de ítems", e);
+        }
+    }
+
+    public void reloadNow(MinecraftServer server) {
+        reloadNow(server.getServerResources().resourceManager());
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/data/model/ItemConfig.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/ItemConfig.java
@@ -1,0 +1,29 @@
+package com.tuempresa.rogue.data.model;
+
+import com.google.gson.JsonObject;
+import com.tuempresa.rogue.data.ItemConfigException;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+
+/**
+ * Configuración genérica para ítems definida vía data packs.
+ */
+public record ItemConfig(int attackIntervalTicks, float baseDamage) {
+    public static ItemConfig fromJson(ResourceLocation id, JsonObject json) {
+        if (json == null) {
+            throw new ItemConfigException("El archivo de configuración de " + id + " está vacío");
+        }
+
+        int interval = GsonHelper.getAsInt(json, "attackIntervalTicks", 0);
+        if (interval < 0) {
+            throw new ItemConfigException("attackIntervalTicks debe ser >= 0 en " + id);
+        }
+
+        float baseDamage = GsonHelper.getAsFloat(json, "baseDamage", 0.0F);
+        if (baseDamage < 0.0F) {
+            throw new ItemConfigException("baseDamage debe ser >= 0 en " + id);
+        }
+
+        return new ItemConfig(interval, baseDamage);
+    }
+}


### PR DESCRIPTION
## Summary
- add a data-driven reload listener to expose item attack configuration
- implement an auto-attack system that fires vanilla projectiles for tagged weapons on the server tick
- apply projectile impact damage based on the configured base damage scaled by active awakenings

## Testing
- not run (gradle wrapper not present)


------
https://chatgpt.com/codex/tasks/task_e_68e06ae844c08326b4a06a9bcbb71ff3