### PR TITLE
Add awakening orb drops and run reset handling

### DIFF
--- a/src/main/java/com/tuempresa/rogue/reward/awakening/ArmorAwakening.java
+++ b/src/main/java/com/tuempresa/rogue/reward/awakening/ArmorAwakening.java
@@ -1,0 +1,65 @@
+package com.tuempresa.rogue.reward.awakening;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+
+import java.util.UUID;
+
+public final class ArmorAwakening {
+    private static final String NBT_KEY = "RogueArmorAwakening";
+    private static final UUID MODIFIER_ID = UUID.fromString("5b985c7b-06ba-46df-9bf5-b831bdb9fee7");
+    private static final double BONUS_PER_LEVEL = 2.0D;
+    private static final int MAX_LEVEL = 3;
+
+    private ArmorAwakening() {
+    }
+
+    public static boolean nextLevel(ServerPlayer player) {
+        int current = getLevel(player);
+        if (current >= MAX_LEVEL) {
+            return false;
+        }
+        int next = current + 1;
+        setLevel(player, next);
+        applyModifier(player, next);
+        return true;
+    }
+
+    public static void reset(ServerPlayer player) {
+        setLevel(player, 0);
+        applyModifier(player, 0);
+    }
+
+    private static int getLevel(ServerPlayer player) {
+        CompoundTag data = player.getPersistentData();
+        return data.getInt(NBT_KEY);
+    }
+
+    private static void setLevel(ServerPlayer player, int level) {
+        CompoundTag data = player.getPersistentData();
+        data.putInt(NBT_KEY, level);
+    }
+
+    private static void applyModifier(ServerPlayer player, int level) {
+        AttributeInstance armor = player.getAttribute(Attributes.ARMOR);
+        if (armor == null) {
+            return;
+        }
+        armor.removePermanentModifier(MODIFIER_ID);
+        armor.removeModifier(MODIFIER_ID);
+        if (level <= 0) {
+            return;
+        }
+        double bonus = BONUS_PER_LEVEL * level;
+        AttributeModifier modifier = new AttributeModifier(
+            MODIFIER_ID,
+            "RogueArmorAwakening",
+            bonus,
+            AttributeModifier.Operation.ADD_VALUE
+        );
+        armor.addPermanentModifier(modifier);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/reward/awakening/WeaponAwakening.java
+++ b/src/main/java/com/tuempresa/rogue/reward/awakening/WeaponAwakening.java
@@ -1,0 +1,65 @@
+package com.tuempresa.rogue.reward.awakening;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+
+import java.util.UUID;
+
+public final class WeaponAwakening {
+    private static final String NBT_KEY = "RogueWeaponAwakening";
+    private static final UUID MODIFIER_ID = UUID.fromString("7c7ae7f1-8105-4c07-9a9c-5191d66efd9e");
+    private static final double BONUS_PER_LEVEL = 1.5D;
+    private static final int MAX_LEVEL = 3;
+
+    private WeaponAwakening() {
+    }
+
+    public static boolean nextLevel(ServerPlayer player) {
+        int current = getLevel(player);
+        if (current >= MAX_LEVEL) {
+            return false;
+        }
+        int next = current + 1;
+        setLevel(player, next);
+        applyModifier(player, next);
+        return true;
+    }
+
+    public static void reset(ServerPlayer player) {
+        setLevel(player, 0);
+        applyModifier(player, 0);
+    }
+
+    private static int getLevel(ServerPlayer player) {
+        CompoundTag data = player.getPersistentData();
+        return data.getInt(NBT_KEY);
+    }
+
+    private static void setLevel(ServerPlayer player, int level) {
+        CompoundTag data = player.getPersistentData();
+        data.putInt(NBT_KEY, level);
+    }
+
+    private static void applyModifier(ServerPlayer player, int level) {
+        AttributeInstance attack = player.getAttribute(Attributes.ATTACK_DAMAGE);
+        if (attack == null) {
+            return;
+        }
+        attack.removePermanentModifier(MODIFIER_ID);
+        attack.removeModifier(MODIFIER_ID);
+        if (level <= 0) {
+            return;
+        }
+        double bonus = BONUS_PER_LEVEL * level;
+        AttributeModifier modifier = new AttributeModifier(
+            MODIFIER_ID,
+            "RogueWeaponAwakening",
+            bonus,
+            AttributeModifier.Operation.ADD_VALUE
+        );
+        attack.addPermanentModifier(modifier);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/spawn/SpawnSystem.java
+++ b/src/main/java/com/tuempresa/rogue/spawn/SpawnSystem.java
@@ -42,7 +42,7 @@ public final class SpawnSystem {
             Optional<Mob> optionalMob = spawnMob(level, entry, state, random);
             optionalMob.ifPresent(mob -> {
                 mob.setPersistenceRequired();
-                applyTags(mob, "rogue_dungeon", "rogue_run:" + run.getId());
+                applyTags(mob, "rogue_dungeon", "rogue_run:" + run.getId(), "rogue_mob");
                 String affinity = state.getDef().affinityTag();
                 if (!affinity.isBlank()) {
                     applyTags(mob, "affinity:" + affinity);


### PR DESCRIPTION
## Summary
- drop awakening-tagged experience orbs from rogue dungeon mobs on death with a 15% chance
- apply armor and weapon awakenings when tagged orbs are picked up by players in an active run and cap them per run
- reset player awakenings when a run finishes or is cleaned up

## Testing
- not run (Gradle wrapper not present)

------
https://chatgpt.com/codex/tasks/task_e_68e06d1e49048326ae45978cf29bcafd