### PR TITLE
Integrate awakening scaling into auto attacks

### DIFF
--- a/src/main/java/com/tuempresa/rogue/data/model/ItemConfig.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/ItemConfig.java
@@ -1,29 +1,116 @@
 package com.tuempresa.rogue.data.model;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.tuempresa.rogue.data.ItemConfigException;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Configuración genérica para ítems definida vía data packs.
  */
-public record ItemConfig(int attackIntervalTicks, float baseDamage) {
+public record ItemConfig(List<Integer> attackIntervals,
+                         float baseDamage,
+                         List<Float> damageMultipliers) {
+
+    public ItemConfig {
+        attackIntervals = List.copyOf(attackIntervals);
+        damageMultipliers = List.copyOf(damageMultipliers);
+    }
+
     public static ItemConfig fromJson(ResourceLocation id, JsonObject json) {
         if (json == null) {
             throw new ItemConfigException("El archivo de configuración de " + id + " está vacío");
         }
 
-        int interval = GsonHelper.getAsInt(json, "attackIntervalTicks", 0);
-        if (interval < 0) {
-            throw new ItemConfigException("attackIntervalTicks debe ser >= 0 en " + id);
-        }
-
+        List<Integer> attackIntervals = parseAttackIntervals(id, json);
         float baseDamage = GsonHelper.getAsFloat(json, "baseDamage", 0.0F);
         if (baseDamage < 0.0F) {
             throw new ItemConfigException("baseDamage debe ser >= 0 en " + id);
         }
+        List<Float> damageMultipliers = parseDamageMultipliers(id, json);
 
-        return new ItemConfig(interval, baseDamage);
+        return new ItemConfig(attackIntervals, baseDamage, damageMultipliers);
+    }
+
+    public int attackInterval(int awakeningLevel) {
+        if (attackIntervals.isEmpty()) {
+            return 0;
+        }
+        int index = Math.max(0, Math.min(awakeningLevel, attackIntervals.size() - 1));
+        return attackIntervals.get(index);
+    }
+
+    public float damageMultiplier(int awakeningLevel) {
+        if (damageMultipliers.isEmpty()) {
+            return 1.0F;
+        }
+        int index = Math.max(0, Math.min(awakeningLevel, damageMultipliers.size() - 1));
+        return damageMultipliers.get(index);
+    }
+
+    private static List<Integer> parseAttackIntervals(ResourceLocation id, JsonObject json) {
+        if (!json.has("attackIntervalTicks")) {
+            return Collections.singletonList(0);
+        }
+        JsonElement element = json.get("attackIntervalTicks");
+        if (element.isJsonArray()) {
+            List<Integer> values = new ArrayList<>();
+            JsonArray array = element.getAsJsonArray();
+            for (int i = 0; i < array.size(); i++) {
+                int value = GsonHelper.convertToInt(array.get(i), "attackIntervalTicks[" + i + "]");
+                if (value < 0) {
+                    throw new ItemConfigException("attackIntervalTicks debe ser >= 0 en " + id);
+                }
+                values.add(value);
+            }
+            if (values.isEmpty()) {
+                throw new ItemConfigException("attackIntervalTicks no puede ser una lista vacía en " + id);
+            }
+            return values;
+        }
+        if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isNumber()) {
+            int value = GsonHelper.convertToInt(element, "attackIntervalTicks");
+            if (value < 0) {
+                throw new ItemConfigException("attackIntervalTicks debe ser >= 0 en " + id);
+            }
+            return Collections.singletonList(value);
+        }
+        throw new ItemConfigException("attackIntervalTicks debe ser un número o una lista en " + id);
+    }
+
+    private static List<Float> parseDamageMultipliers(ResourceLocation id, JsonObject json) {
+        if (!json.has("damageMultiplier")) {
+            return Collections.singletonList(1.0F);
+        }
+        JsonElement element = json.get("damageMultiplier");
+        if (element.isJsonArray()) {
+            List<Float> values = new ArrayList<>();
+            JsonArray array = element.getAsJsonArray();
+            for (int i = 0; i < array.size(); i++) {
+                float value = GsonHelper.convertToFloat(array.get(i), "damageMultiplier[" + i + "]");
+                if (value < 0.0F) {
+                    throw new ItemConfigException("damageMultiplier debe ser >= 0 en " + id);
+                }
+                values.add(value);
+            }
+            if (values.isEmpty()) {
+                throw new ItemConfigException("damageMultiplier no puede ser una lista vacía en " + id);
+            }
+            return values;
+        }
+        if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isNumber()) {
+            float value = GsonHelper.convertToFloat(element, "damageMultiplier");
+            if (value < 0.0F) {
+                throw new ItemConfigException("damageMultiplier debe ser >= 0 en " + id);
+            }
+            return Collections.singletonList(value);
+        }
+        throw new ItemConfigException("damageMultiplier debe ser un número o una lista en " + id);
     }
 }

--- a/src/main/java/com/tuempresa/rogue/reward/awakening/ArmorAwakening.java
+++ b/src/main/java/com/tuempresa/rogue/reward/awakening/ArmorAwakening.java
@@ -33,7 +33,7 @@ public final class ArmorAwakening {
         applyModifier(player, 0);
     }
 
-    private static int getLevel(ServerPlayer player) {
+    public static int getLevel(ServerPlayer player) {
         CompoundTag data = player.getPersistentData();
         return data.getInt(NBT_KEY);
     }

--- a/src/main/java/com/tuempresa/rogue/reward/awakening/WeaponAwakening.java
+++ b/src/main/java/com/tuempresa/rogue/reward/awakening/WeaponAwakening.java
@@ -33,7 +33,7 @@ public final class WeaponAwakening {
         applyModifier(player, 0);
     }
 
-    private static int getLevel(ServerPlayer player) {
+    public static int getLevel(ServerPlayer player) {
         CompoundTag data = player.getPersistentData();
         return data.getInt(NBT_KEY);
     }

--- a/src/main/resources/data/rogue/config/items/arco_pesado.json
+++ b/src/main/resources/data/rogue/config/items/arco_pesado.json
@@ -1,4 +1,5 @@
 {
-  "attackIntervalTicks": 24,
-  "baseDamage": 6
+  "attackIntervalTicks": [24, 22, 20, 18],
+  "baseDamage": 6,
+  "damageMultiplier": [1.0, 1.1, 1.25, 1.5]
 }

--- a/src/main/resources/data/rogue/config/items/armadura_ligera.json
+++ b/src/main/resources/data/rogue/config/items/armadura_ligera.json
@@ -1,4 +1,5 @@
 {
-  "attackIntervalTicks": 20,
-  "baseDamage": 2
+  "attackIntervalTicks": [20, 18, 16, 14],
+  "baseDamage": 2,
+  "damageMultiplier": [1.0, 1.05, 1.1, 1.2]
 }

--- a/src/main/resources/data/rogue/config/items/armadura_reforzada.json
+++ b/src/main/resources/data/rogue/config/items/armadura_reforzada.json
@@ -1,4 +1,5 @@
 {
-  "attackIntervalTicks": 32,
-  "baseDamage": 4
+  "attackIntervalTicks": [32, 30, 28, 26],
+  "baseDamage": 4,
+  "damageMultiplier": [1.0, 1.1, 1.2, 1.35]
 }

--- a/src/main/resources/data/rogue/config/items/varita_rapida.json
+++ b/src/main/resources/data/rogue/config/items/varita_rapida.json
@@ -1,4 +1,5 @@
 {
-  "attackIntervalTicks": 16,
-  "baseDamage": 3
+  "attackIntervalTicks": [16, 14, 12, 10],
+  "baseDamage": 3,
+  "damageMultiplier": [1.0, 1.15, 1.35, 1.6]
 }


### PR DESCRIPTION
## Summary
- add per-level attack interval and damage multiplier scaling driven by awakening levels and data configs
- extend auto attack behaviour with level 3 wand fan shots and arrow piercing plus data-driven damage
- grant reforged armor level 1 and 2 temporary defensive buffs during dungeon runs and expose awakening levels

## Testing
- gradle build *(fails: net.neoforged.gradle plugin unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e07077a8148326a32a34f48c332a42