### PR TITLE
Add QA tools and messaging for awakening levels

### DIFF
--- a/src/main/java/com/tuempresa/rogue/core/RogueCommandEvents.java
+++ b/src/main/java/com/tuempresa/rogue/core/RogueCommandEvents.java
@@ -1,6 +1,7 @@
 package com.tuempresa.rogue.core;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.tuempresa.rogue.core.command.RogueAwakeningCommand;
 import com.tuempresa.rogue.core.command.RogueConfigCommand;
 import com.tuempresa.rogue.core.command.RogueDataCommand;
 import com.tuempresa.rogue.core.command.RogueGoldCommand;
@@ -23,6 +24,7 @@ public final class RogueCommandEvents {
         RogueRunsCommand.register(root);
         RogueWarpCommand.register(root);
         RogueConfigCommand.register(root);
+        RogueAwakeningCommand.register(root);
 
         event.getDispatcher().register(root);
         RogueShopCommand.register(event.getDispatcher());

--- a/src/main/java/com/tuempresa/rogue/core/command/RogueAwakeningCommand.java
+++ b/src/main/java/com/tuempresa/rogue/core/command/RogueAwakeningCommand.java
@@ -1,0 +1,77 @@
+package com.tuempresa.rogue.core.command;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.tuempresa.rogue.reward.awakening.ArmorAwakening;
+import com.tuempresa.rogue.reward.awakening.WeaponAwakening;
+import com.tuempresa.rogue.util.Chat;
+import com.tuempresa.rogue.util.RogueLogger;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
+import java.util.Locale;
+
+public final class RogueAwakeningCommand {
+    private static final SimpleCommandExceptionType UNKNOWN_TYPE = new SimpleCommandExceptionType(
+        Component.literal("Tipo de despertar desconocido. Usa arma, armadura o ambos.")
+    );
+    private static final List<String> TYPES = List.of("arma", "armadura", "ambos");
+
+    private RogueAwakeningCommand() {
+    }
+
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> root) {
+        root.then(Commands.literal("awakening")
+            .then(Commands.literal("set")
+                .then(Commands.argument("jugador", EntityArgument.player())
+                    .then(Commands.argument("tipo", StringArgumentType.word())
+                        .suggests((ctx, builder) -> SharedSuggestionProvider.suggest(TYPES, builder))
+                        .then(Commands.argument("nivel", IntegerArgumentType.integer(0))
+                            .executes(ctx -> setLevel(
+                                ctx.getSource(),
+                                EntityArgument.getPlayer(ctx, "jugador"),
+                                StringArgumentType.getString(ctx, "tipo"),
+                                IntegerArgumentType.getInteger(ctx, "nivel")
+                            )))))));
+    }
+
+    private static int setLevel(CommandSourceStack source, ServerPlayer player, String type, int level)
+        throws CommandSyntaxException {
+        String normalized = type.toLowerCase(Locale.ROOT);
+        int weaponLevel = WeaponAwakening.getLevel(player);
+        int armorLevel = ArmorAwakening.getLevel(player);
+        switch (normalized) {
+            case "arma" -> weaponLevel = WeaponAwakening.setLevel(player, level);
+            case "armadura" -> armorLevel = ArmorAwakening.setLevel(player, level);
+            case "ambos" -> {
+                weaponLevel = WeaponAwakening.setLevel(player, level);
+                armorLevel = ArmorAwakening.setLevel(player, level);
+            }
+            default -> throw UNKNOWN_TYPE.create();
+        }
+        source.sendSuccess(
+            () -> Component.literal(
+                "Niveles de despertar de " + player.getName().getString() + ": arma=" + weaponLevel + ", armadura=" + armorLevel
+            ),
+            true
+        );
+        if (source.getEntity() != player) {
+            Chat.tip(player, "Tus niveles de despertar ahora son arma=" + weaponLevel + " y armadura=" + armorLevel + ".");
+        }
+        RogueLogger.debug(
+            "Comando QA ajusta despertar de {} (arma={}, armadura={})",
+            player.getGameProfile().getName(),
+            weaponLevel,
+            armorLevel
+        );
+        return Math.max(weaponLevel, armorLevel);
+    }
+}

--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonEvents.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonEvents.java
@@ -4,6 +4,8 @@ import com.tuempresa.rogue.RogueMod;
 import com.tuempresa.rogue.dungeon.instance.DungeonRun;
 import com.tuempresa.rogue.reward.awakening.ArmorAwakening;
 import com.tuempresa.rogue.reward.awakening.WeaponAwakening;
+import com.tuempresa.rogue.util.Chat;
+import com.tuempresa.rogue.util.RogueLogger;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -98,8 +100,19 @@ public final class DungeonEvents {
 
         DungeonManager.findRunByPlayer(serverPlayer.getUUID()).ifPresent(run -> {
             if (run.grantAwakening(serverPlayer)) {
-                ArmorAwakening.nextLevel(serverPlayer);
-                WeaponAwakening.nextLevel(serverPlayer);
+                boolean armorUp = ArmorAwakening.nextLevel(serverPlayer);
+                boolean weaponUp = WeaponAwakening.nextLevel(serverPlayer);
+                int armorLevel = ArmorAwakening.getLevel(serverPlayer);
+                int weaponLevel = WeaponAwakening.getLevel(serverPlayer);
+                if (armorUp || weaponUp) {
+                    Chat.success(serverPlayer, "¡Tu despertar aumenta! Armadura: " + armorLevel + " | Arma: " + weaponLevel);
+                }
+                RogueLogger.debug(
+                    "Jugador {} sube despertar (arma={}, armadura={})",
+                    serverPlayer.getGameProfile().getName(),
+                    weaponLevel,
+                    armorLevel
+                );
             }
         });
     }

--- a/src/main/java/com/tuempresa/rogue/reward/awakening/ArmorAwakening.java
+++ b/src/main/java/com/tuempresa/rogue/reward/awakening/ArmorAwakening.java
@@ -5,6 +5,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.util.Mth;
 
 import java.util.UUID;
 
@@ -24,13 +25,18 @@ public final class ArmorAwakening {
         }
         int next = current + 1;
         setLevel(player, next);
-        applyModifier(player, next);
         return true;
+    }
+
+    public static int setLevel(ServerPlayer player, int level) {
+        int clamped = Mth.clamp(level, 0, MAX_LEVEL);
+        writeLevel(player, clamped);
+        applyModifier(player, clamped);
+        return clamped;
     }
 
     public static void reset(ServerPlayer player) {
         setLevel(player, 0);
-        applyModifier(player, 0);
     }
 
     public static int getLevel(ServerPlayer player) {
@@ -38,7 +44,7 @@ public final class ArmorAwakening {
         return data.getInt(NBT_KEY);
     }
 
-    private static void setLevel(ServerPlayer player, int level) {
+    private static void writeLevel(ServerPlayer player, int level) {
         CompoundTag data = player.getPersistentData();
         data.putInt(NBT_KEY, level);
     }

--- a/src/main/java/com/tuempresa/rogue/reward/awakening/WeaponAwakening.java
+++ b/src/main/java/com/tuempresa/rogue/reward/awakening/WeaponAwakening.java
@@ -5,6 +5,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.util.Mth;
 
 import java.util.UUID;
 
@@ -24,13 +25,18 @@ public final class WeaponAwakening {
         }
         int next = current + 1;
         setLevel(player, next);
-        applyModifier(player, next);
         return true;
+    }
+
+    public static int setLevel(ServerPlayer player, int level) {
+        int clamped = Mth.clamp(level, 0, MAX_LEVEL);
+        writeLevel(player, clamped);
+        applyModifier(player, clamped);
+        return clamped;
     }
 
     public static void reset(ServerPlayer player) {
         setLevel(player, 0);
-        applyModifier(player, 0);
     }
 
     public static int getLevel(ServerPlayer player) {
@@ -38,7 +44,7 @@ public final class WeaponAwakening {
         return data.getInt(NBT_KEY);
     }
 
-    private static void setLevel(ServerPlayer player, int level) {
+    private static void writeLevel(ServerPlayer player, int level) {
         CompoundTag data = player.getPersistentData();
         data.putInt(NBT_KEY, level);
     }

--- a/src/main/java/com/tuempresa/rogue/util/RogueLogger.java
+++ b/src/main/java/com/tuempresa/rogue/util/RogueLogger.java
@@ -1,6 +1,7 @@
 package com.tuempresa.rogue.util;
 
 import com.mojang.logging.LogUtils;
+import com.tuempresa.rogue.config.RogueConfig;
 import org.slf4j.Logger;
 
 /**
@@ -26,5 +27,11 @@ public final class RogueLogger {
 
     public static void error(String message, Object... args) {
         LOGGER.error(message, args);
+    }
+
+    public static void debug(String message, Object... args) {
+        if (RogueConfig.logVerbose()) {
+            LOGGER.debug(message, args);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add celebratory chat messaging and optional debug logs when players gain awakening levels
- expose a QA-only `/rogue awakening set` command to adjust weapon and armor awakening levels
- allow manual level adjustments through new setters that clamp values and refresh attribute modifiers

## Testing
- not run (no `gradlew` script provided)


------
https://chatgpt.com/codex/tasks/task_e_68e072509fa4832696af40e7940c073d