### PR TITLE
Expose awakening drop rates and portal rewards in config

### DIFF
--- a/src/main/java/com/tuempresa/rogue/config/RogueConfig.java
+++ b/src/main/java/com/tuempresa/rogue/config/RogueConfig.java
@@ -43,6 +43,23 @@ public final class RogueConfig {
         return COMMON.logVerbose.get();
     }
 
+    public static double awakeningDropChanceCommon() {
+        return COMMON.awakeningDropChanceCommon.get();
+    }
+
+    public static double awakeningDropChanceBoss() {
+        return COMMON.awakeningDropChanceBoss.get();
+    }
+
+    public static int portalTierraGoldMin() {
+        return COMMON.portalTierraGoldMin.get();
+    }
+
+    public static int portalTierraGoldMax() {
+        int min = portalTierraGoldMin();
+        return Math.max(min, COMMON.portalTierraGoldMax.get());
+    }
+
     public static BlockPos cityPortalPos() {
         List<? extends Integer> raw = COMMON.cityPortalPos.get();
         int x = raw.size() > 0 ? raw.get(0) : 0;
@@ -61,6 +78,10 @@ public final class RogueConfig {
         final ModConfigSpec.IntValue maxAliveDefault;
         final ModConfigSpec.IntValue roomTimeLimitSeconds;
         final ModConfigSpec.BooleanValue logVerbose;
+        final ModConfigSpec.DoubleValue awakeningDropChanceCommon;
+        final ModConfigSpec.DoubleValue awakeningDropChanceBoss;
+        final ModConfigSpec.IntValue portalTierraGoldMin;
+        final ModConfigSpec.IntValue portalTierraGoldMax;
         final ModConfigSpec.ConfigValue<List<? extends Integer>> cityPortalPos;
         final ModConfigSpec.ConfigValue<String> cityPortalDungeon;
 
@@ -72,6 +93,18 @@ public final class RogueConfig {
             builder.comment("Valores por defecto de mazmorras").push("dungeons");
             maxAliveDefault = builder.defineInRange("maxAliveDefault", 12, 1, 100);
             roomTimeLimitSeconds = builder.defineInRange("roomTimeLimitSeconds", 300, 10, 3600);
+            builder.pop();
+
+            builder.comment("Botín y recompensas").push("rewards");
+            builder.comment("Probabilidad de que caigan orbes de despertar al derrotar mobs").push("awakening");
+            awakeningDropChanceCommon = builder.defineInRange("awakeningDropChanceCommon", 0.15D, 0.0D, 1.0D);
+            awakeningDropChanceBoss = builder.defineInRange("awakeningDropChanceBoss", 0.15D, 0.0D, 1.0D);
+            builder.pop();
+
+            builder.comment("Recompensas de oro específicas del portal de Tierra").push("portalTierra");
+            portalTierraGoldMin = builder.defineInRange("goldMin", 180, 0, 10000);
+            portalTierraGoldMax = builder.defineInRange("goldMax", 260, 0, 10000);
+            builder.pop();
             builder.pop();
 
             builder.comment("Configuración del mundo hub").push("hub");

--- a/src/main/java/com/tuempresa/rogue/data/model/DungeonDef.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/DungeonDef.java
@@ -67,7 +67,7 @@ public final class DungeonDef {
         List<RoomDef> rooms = new ArrayList<>();
         roomsArray.forEach(element -> rooms.add(RoomDef.fromJson(GsonHelper.convertToJsonObject(element, "room"))));
 
-        RewardsDef rewards = RewardsDef.fromJson(GsonHelper.getAsJsonObject(json, "rewards"));
+        RewardsDef rewards = RewardsDef.fromJson(id, GsonHelper.getAsJsonObject(json, "rewards"));
 
         return new DungeonDef(id, levelMin, entryCost, world, rooms, rewards);
     }

--- a/src/main/java/com/tuempresa/rogue/data/model/RewardsDef.java
+++ b/src/main/java/com/tuempresa/rogue/data/model/RewardsDef.java
@@ -1,6 +1,8 @@
 package com.tuempresa.rogue.data.model;
 
 import com.google.gson.JsonObject;
+import com.tuempresa.rogue.config.RogueConfig;
+import com.tuempresa.rogue.core.RogueConstants;
 import com.tuempresa.rogue.data.DungeonDataException;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
@@ -46,7 +48,7 @@ public final class RewardsDef {
         return cosmeticChance;
     }
 
-    public static RewardsDef fromJson(JsonObject json) {
+    public static RewardsDef fromJson(ResourceLocation dungeonId, JsonObject json) {
         int goldMin = Math.max(0, GsonHelper.getAsInt(json, "goldMin", 0));
         int goldMax = Math.max(goldMin, GsonHelper.getAsInt(json, "goldMax", goldMin));
 
@@ -59,6 +61,13 @@ public final class RewardsDef {
         int materialMin = Math.max(0, GsonHelper.getAsInt(json, "materialMin", 0));
         int materialMax = Math.max(materialMin, GsonHelper.getAsInt(json, "materialMax", materialMin));
         double cosmeticChance = Math.max(0.0, GsonHelper.getAsDouble(json, "cosmeticChance", 0.0));
+
+        if (dungeonId.equals(RogueConstants.id("portal_tierra"))) {
+            int configMin = RogueConfig.portalTierraGoldMin();
+            int configMax = RogueConfig.portalTierraGoldMax();
+            goldMin = Math.max(0, configMin);
+            goldMax = Math.max(goldMin, configMax);
+        }
 
         return new RewardsDef(goldMin, goldMax, materialId, materialMin, materialMax, cosmeticChance);
     }

--- a/src/main/java/com/tuempresa/rogue/dungeon/DungeonEvents.java
+++ b/src/main/java/com/tuempresa/rogue/dungeon/DungeonEvents.java
@@ -1,6 +1,7 @@
 package com.tuempresa.rogue.dungeon;
 
 import com.tuempresa.rogue.RogueMod;
+import com.tuempresa.rogue.config.RogueConfig;
 import com.tuempresa.rogue.dungeon.instance.DungeonRun;
 import com.tuempresa.rogue.reward.awakening.ArmorAwakening;
 import com.tuempresa.rogue.reward.awakening.WeaponAwakening;
@@ -69,7 +70,10 @@ public final class DungeonEvents {
             runOptional.ifPresent(run -> {
                 run.onMobKilled(server, mob.getUUID());
                 if (mob.getTags().contains("rogue_mob") && mob.level() instanceof ServerLevel level) {
-                    if (level.getRandom().nextDouble() < 0.15D) {
+                    double dropChance = mob.getTags().contains("rogue_boss")
+                        ? RogueConfig.awakeningDropChanceBoss()
+                        : RogueConfig.awakeningDropChanceCommon();
+                    if (level.getRandom().nextDouble() < dropChance) {
                         ExperienceOrb orb = new ExperienceOrb(level, mob.getX(), mob.getY(), mob.getZ(), 1);
                         orb.addTag("awakening");
                         level.addFreshEntity(orb);

--- a/src/main/resources/rogue-common.toml
+++ b/src/main/resources/rogue-common.toml
@@ -10,6 +10,18 @@ maxAliveDefault = 12
 # Tiempo límite por sala en segundos.
 roomTimeLimitSeconds = 300
 
+[rewards.awakening]
+# Probabilidad de obtener un orbe de despertar al derrotar mobs normales.
+awakeningDropChanceCommon = 0.15
+# Probabilidad de obtener un orbe de despertar al derrotar jefes marcados.
+awakeningDropChanceBoss = 0.15
+
+[rewards.portalTierra]
+# Cantidad mínima de oro entregada al completar el portal de Tierra.
+goldMin = 180
+# Cantidad máxima de oro entregada al completar el portal de Tierra.
+goldMax = 260
+
 [hub]
 # Posición (X,Y,Z) donde se ubicará el portal inicial de la ciudad.
 cityPortalPos = [0, 65, 0]


### PR DESCRIPTION
## Summary
- add common configuration entries for awakening orb drop chances and the Earth portal gold rewards
- use the configured values when spawning awakening orbs and when loading the Earth portal dungeon rewards

## Testing
- `./gradlew build` *(fails: Gradle wrapper script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e0734fd37c8326b6ed2e3ca38edb5f