### PR TITLE
Remove explicit mappings configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,9 +28,6 @@ repositories {
 
 neoForge {
     version = "21.1.1"
-    mappings {
-        official()
-    }
 }
 
 sourceSets {


### PR DESCRIPTION
## Summary
- remove the explicit official mappings block from the neoForge configuration so the moddev plugin defaults apply

## Testing
- ./gradlew wrapper *(fails: ./gradlew: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e084f02f8c832699f7cf454a42d853